### PR TITLE
fix(add): add timestamps to schema

### DIFF
--- a/goblinhub-api/prisma/schema.prisma
+++ b/goblinhub-api/prisma/schema.prisma
@@ -104,6 +104,7 @@ model Usuario {
   id_usuario_creador   String?              @db.Uuid
   created_at           DateTime             @default(now())
   updated_at           DateTime             @updatedAt
+  deleted_at           DateTime?            @db.Timestamp(6)
 
   // Relaciones
   usuarioCreador       Usuario?             @relation("UsuarioCreador", fields: [id_usuario_creador], references: [id_usuario])
@@ -125,6 +126,9 @@ model Interes {
   id_interes       Int                  @id @default(autoincrement())
   nombre_interes   TipoInteres          @unique
   descripcion      String?
+  created_at       DateTime             @default(now())
+  updated_at       DateTime             @updatedAt
+  deleted_at       DateTime?            @db.Timestamp(6)
 
   // Relaciones
   usuarios         Usuario_Interes[]
@@ -182,6 +186,8 @@ model Evento {
   puntos_participacion Int                  @default(50)
   id_creador           String               @db.Uuid
   created_at           DateTime             @default(now())
+  updated_at           DateTime             @updatedAt
+  deleted_at           DateTime?            @db.Timestamp(6)
 
   // Relaciones
   creador              Usuario              @relation("EventoCreador", fields: [id_creador], references: [id_usuario])
@@ -203,6 +209,7 @@ model Inscripcion {
   es_ganador           Boolean              @default(false)
   puntos_obtenidos     Int                  @default(0)
   fecha_inscripcion    DateTime             @default(now())
+  deleted_at           DateTime?            @db.Timestamp(6)
 
   // Relaciones
   evento               Evento               @relation(fields: [id_evento], references: [id_evento], onDelete: Cascade)
@@ -230,6 +237,7 @@ model Producto {
   activo               Boolean              @default(true)
   created_at           DateTime             @default(now())
   updated_at           DateTime             @updatedAt
+  deleted_at           DateTime?            @db.Timestamp(6)
 
   @@map("productos")
 }
@@ -249,6 +257,8 @@ model Captacion_Novato {
   rating_experiencia   Int?                 @db.SmallInt // CHECK (1-5) would be validated at application level
   comentarios          String?
   created_at           DateTime             @default(now())
+  updated_at           DateTime             @updatedAt
+  deleted_at           DateTime?            @db.Timestamp(6)
 
   // Relaciones
   usuario              Usuario              @relation(fields: [id_usuario], references: [id_usuario], onDelete: Cascade)
@@ -284,6 +294,9 @@ model Recompensa {
   tipo                 TipoRecompensa
   valor_descuento      Decimal?             @db.Decimal(5, 2)
   activa               Boolean              @default(true)
+  created_at           DateTime             @default(now())
+  updated_at           DateTime             @updatedAt
+  deleted_at           DateTime?            @db.Timestamp(6)
 
   // Relaciones
   canjes               Canje[]


### PR DESCRIPTION
Branch: fix/14-add-schema-timestamps
Fixes: #14

## 📌 Resumen del Cambio

Se agregan los campos de timestamps (`created_at`, `updated_at`, `deleted_at`) al schema de la base de datos, los cuales se habían omitido previamente.

Esto permite llevar control de creación, actualización y borrado lógico de los registros.

---

## 🔍 Tipo de Cambio realizado

Marca con una `x` lo que aplica:

* [x] 🐞 Corrección de error (`fix`)
* [ ] ✨ Nueva funcionalidad (`feat`)
* [ ] ♻️ Refactorización del código sin cambios funcionales (`refactor`)
* [ ] 🧪 Agregado o mejora de pruebas (`test`)
* [ ] 🧱 Cambio en configuración CI/CD (`ci`)
* [ ] 🚀 Mejora de rendimiento (`perf`)
* [ ] 📚 Cambios en la documentación (`docs`)
* [ ] Otro (especificar):

---

## 📂 Archivos Afectados

* `prisma/schema.prisma`
* `prisma/migrations/`

---

## 🧪 ¿Cómo Probarlo?

1. Ejecutar:

   ```bash
   npm install
   ```

2. Ejecutar migraciones:

   ```bash
   npx prisma migrate dev
   ```

3. Generar el cliente:

   ```bash
   npx prisma generate
   ```

4. Verificar en la base de datos que las tablas ahora contienen los campos:

   * `created_at`
   * `updated_at`
   * `deleted_at`

---

## ✅ Checklist

* [x] He probado mis cambios localmente
* [x] Esta PR sigue el formato de convención de commits (si aplica)
* [ ] Se han actualizado o agregado pruebas
* [ ] La documentación se actualizó si fue necesario
* [x] No hay errores en CI/CD

---

## 📎 Notas Adicionales

Se utiliza `deleted_at` para soportar soft delete en futuras implementaciones del sistema.
