### PR TITLE
Feat/15 supabase auth

### DIFF
--- a/goblinhub-api/src/app.module.ts
+++ b/goblinhub-api/src/app.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { EventModule } from './modules/events/event.module';
 import { ConfigModule } from '@nestjs/config';
+import { SupabaseAuthModule } from './modules/supabase/supabase-auth.module';
 
 @Module({
   imports: [
@@ -8,6 +9,7 @@ import { ConfigModule } from '@nestjs/config';
       isGlobal: true, // ← importante, lo hace disponible en toda la app
     }),
     EventModule,
+    SupabaseAuthModule,
   ],
   controllers: [],
   providers: [],

--- a/goblinhub-api/src/main.ts
+++ b/goblinhub-api/src/main.ts
@@ -4,6 +4,14 @@ import { ValidationPipe } from '@nestjs/common';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+
+  app.enableCors({
+    origin: process.env.CORS_ORIGIN?.split(',') ?? [],
+    methods: ['GET', 'POST', 'PUT', 'DELETE'],
+    allowedHeaders: ['Content-Type', 'Authorization'],
+    credentials: true,
+  });
+
   app.useGlobalPipes(
     new ValidationPipe({
       whitelist: true, // elimina campos que no están en el DTO
@@ -11,6 +19,7 @@ async function bootstrap() {
       transform: true, // convierte los tipos automáticamente
     }),
   );
+
   await app.listen(process.env.PORT ?? 3000);
 }
 void bootstrap();

--- a/goblinhub-api/src/modules/events/event.module.ts
+++ b/goblinhub-api/src/modules/events/event.module.ts
@@ -7,6 +7,7 @@ import { getEventUseCase } from './aplication/use-case/get-event.use-case';
 import { EventRepository } from './domain/repositories/event.repository';
 import { EventRepositoryPrisma } from './infrastructure/prisma/event.repository';
 import { PrismaModule } from 'src/connect/prisma.module';
+import { SupabaseAuthModule } from '../supabase/supabase-auth.module';
 
 @Module({
   controllers: [EventController],
@@ -20,6 +21,6 @@ import { PrismaModule } from 'src/connect/prisma.module';
       useClass: EventRepositoryPrisma,
     },
   ],
-  imports: [PrismaModule],
+  imports: [PrismaModule, SupabaseAuthModule],
 })
 export class EventModule {}

--- a/goblinhub-api/src/modules/events/interfaces/controllers/event.controller.ts
+++ b/goblinhub-api/src/modules/events/interfaces/controllers/event.controller.ts
@@ -7,6 +7,9 @@ import {
   Post,
   Put,
   Query,
+  Request,
+  UnauthorizedException,
+  UseGuards,
 } from '@nestjs/common';
 import { CreateEventUseCase } from '../../aplication/use-case/create-event.use-case';
 import { UpdateEventUseCase } from '../../aplication/use-case/update-event.use-case';
@@ -15,6 +18,8 @@ import { getEventUseCase } from '../../aplication/use-case/get-event.use-case';
 import { Event } from '../../domain/entities/event.entity';
 import { CreateEventDto } from '../../aplication/dtos/create-event.dto';
 import { UpdateEventDto } from '../../aplication/dtos/update-event.dto';
+import { SupabaseAuthGuard } from '../../../supabase/guard/supabse-auth.guard';
+import type { AuthenticatedRequest } from '../../../supabase/interfaces/types/authenticated-request.interface';
 
 @Controller('events')
 export class EventController {
@@ -37,13 +42,18 @@ export class EventController {
   }
 
   @Post()
-  async createEvent(@Body() createEventDto: CreateEventDto): Promise<Event> {
-    // TODO: Extraer id_creador del JWT cuando implementes autenticación
-    const id_creador = '6bd55604-98c9-4940-b901-5d3a255d7535'; // UUID temporal
+  @UseGuards(SupabaseAuthGuard)
+  async createEvent(
+    @Body() createEventDto: CreateEventDto,
+    @Request() req: AuthenticatedRequest,
+  ): Promise<Event> {
+    if (!req.user) throw new UnauthorizedException('User not authenticated');
+    const id_creador = req.user.id;
     return await this.created.createEvent(createEventDto, id_creador);
   }
 
   @Put(':id')
+  @UseGuards(SupabaseAuthGuard)
   async updateEvent(
     @Param('id') id: string,
     @Body() updateEventDto: UpdateEventDto,
@@ -52,6 +62,7 @@ export class EventController {
   }
 
   @Delete(':id')
+  @UseGuards(SupabaseAuthGuard)
   async deleteEvent(@Param('id') id: string): Promise<Event> {
     return await this.deleted.softDeleteEvent(id);
   }

--- a/goblinhub-api/src/modules/supabase/application/dto/auth.dto.ts
+++ b/goblinhub-api/src/modules/supabase/application/dto/auth.dto.ts
@@ -1,0 +1,27 @@
+import { IsString, IsEmail } from 'class-validator';
+
+export class validateTokenDto {
+  @IsString()
+  token: string;
+}
+
+export class RefreshTokenDto {
+  @IsString()
+  refreshToken: string;
+}
+
+export class CreateTesruserDto {
+  @IsEmail()
+  email: string;
+
+  @IsString()
+  password: string;
+}
+
+export class SignInTestuserDto {
+  @IsEmail()
+  email: string;
+
+  @IsString()
+  password: string;
+}

--- a/goblinhub-api/src/modules/supabase/application/use-case/create-test-user.use-case.ts
+++ b/goblinhub-api/src/modules/supabase/application/use-case/create-test-user.use-case.ts
@@ -1,0 +1,93 @@
+import { BadRequestException, Inject, Injectable } from '@nestjs/common';
+import { SupabaseClient } from '@supabase/supabase-js';
+
+@Injectable()
+export class SupabaseCreateTestUserService {
+  constructor(
+    @Inject('SUPABASE_CLIENT') private readonly supabase: SupabaseClient,
+  ) {}
+
+  async createTestUser(email: string, password: string) {
+    try {
+      // crea el usuario en la tabla auth
+      const { data, error } = await this.supabase.auth.signUp({
+        email,
+        password,
+        options: {
+          // En modo testing, puedes confirmar automáticamente el email
+          emailRedirectTo: undefined,
+        },
+      });
+
+      if (error) {
+        throw new BadRequestException(`Error Creating User: ${error.message}`);
+      }
+
+      if (!data.user) {
+        throw new BadRequestException('User not created');
+      }
+
+      return {
+        success: true,
+        user: {
+          id: data.user.id,
+          email: data.user.email,
+          create_at: data.user.created_at,
+        },
+        session: data.session,
+        message: 'Usuario creado exitosamente',
+      };
+    } catch (error) {
+      if (error instanceof BadRequestException) {
+        throw error;
+      }
+      throw new BadRequestException('Error al crear usuario de prueba');
+    }
+  }
+
+  async signInTestuser(email: string, password: string) {
+    try {
+      const { data, error } = await this.supabase.auth.signInWithPassword({
+        email,
+        password,
+      });
+
+      if (error) {
+        throw new BadRequestException(`Error signin in: ${error.message}`);
+      }
+      if (!data.session) {
+        throw new BadRequestException('No session created');
+      }
+
+      return {
+        success: true,
+        user: data.user,
+        session: data.session,
+        access_token: data.session.access_token,
+        refreshToken: data.session.refresh_token,
+        message: 'Login exitoso',
+      };
+    } catch (error) {
+      if (error instanceof BadRequestException) {
+        throw error;
+      }
+      throw new BadRequestException('Error al hacer login');
+    }
+  }
+
+  listAuthUsers() {
+    try {
+      // Nota: Para listar usuarios necesitarías usar el Admin API
+      // Por ahora, este método es un placeholder
+      return {
+        success: true,
+        message:
+          'Para ver todos los usuarios necesitas acceso admin a Supabase',
+        instructions:
+          'Ve a tu panel de Supabase > Authentication > Users para ver los usuarios creados',
+      };
+    } catch {
+      throw new BadRequestException('Error al obtener lista de usuarios');
+    }
+  }
+}

--- a/goblinhub-api/src/modules/supabase/application/use-case/getUserProfile.use-case.ts
+++ b/goblinhub-api/src/modules/supabase/application/use-case/getUserProfile.use-case.ts
@@ -1,0 +1,41 @@
+import { Inject, Injectable, UnauthorizedException } from '@nestjs/common';
+import { SupabaseClient } from '@supabase/supabase-js';
+
+@Injectable()
+export class SupabaseGetUserProfileService {
+  constructor(
+    @Inject('SUPABASE_CLIENT') private readonly supabase: SupabaseClient,
+  ) {}
+
+  async getUserProfile(token: string) {
+    try {
+      const { data: user, error } = await this.supabase.auth.getUser(token);
+
+      if (error) {
+        throw new UnauthorizedException(
+          `Failed to retrieve user profile: ${error.message}`,
+        );
+      }
+
+      if (!user || !user.user) {
+        throw new UnauthorizedException(
+          'Failed to retrieve user profile: No user data returned',
+        );
+      }
+
+      return {
+        success: true,
+        user: {
+          id: user.user.id,
+          email: user.user.email,
+          createdAt: user.user.created_at,
+        },
+        message: 'User profile retrieved successfully',
+      };
+    } catch (error) {
+      if (error instanceof UnauthorizedException) {
+        throw error;
+      }
+    }
+  }
+}

--- a/goblinhub-api/src/modules/supabase/application/use-case/refreshT.use-case.ts
+++ b/goblinhub-api/src/modules/supabase/application/use-case/refreshT.use-case.ts
@@ -1,0 +1,28 @@
+import { Inject, Injectable, UnauthorizedException } from '@nestjs/common';
+import { SupabaseClient } from '@supabase/supabase-js';
+
+@Injectable()
+export class SupabaseRefreshTokenService {
+  constructor(
+    @Inject('SUPABASE_CLIENT') private readonly supabase: SupabaseClient,
+  ) {}
+
+  async refreshToken(refreshToken: string) {
+    try {
+      const { data, error } = await this.supabase.auth.refreshSession({
+        refresh_token: refreshToken,
+      });
+
+      if (error) {
+        throw new UnauthorizedException(error.message);
+      }
+
+      return {
+        success: true,
+        session: data,
+      };
+    } catch {
+      throw new UnauthorizedException('Failed to refresh token');
+    }
+  }
+}

--- a/goblinhub-api/src/modules/supabase/application/use-case/validationT.use-case.ts
+++ b/goblinhub-api/src/modules/supabase/application/use-case/validationT.use-case.ts
@@ -1,0 +1,27 @@
+import { Inject, Injectable, UnauthorizedException } from '@nestjs/common';
+import { SupabaseClient } from '@supabase/supabase-js';
+
+@Injectable()
+export class SupabaseValidationTokenService {
+  constructor(
+    @Inject('SUPABASE_CLIENT') private readonly supabase: SupabaseClient,
+  ) {}
+
+  async validtoken(token: string) {
+    try {
+      const { data: user, error } = await this.supabase.auth.getUser(token);
+
+      if (error || !user || !user.user) {
+        throw new UnauthorizedException(`Failed to validate token`);
+      }
+
+      return {
+        success: true,
+        user: user.user,
+        message: 'Token is valid',
+      };
+    } catch {
+      throw new UnauthorizedException('Failed to validate token');
+    }
+  }
+}

--- a/goblinhub-api/src/modules/supabase/guard/supabse-auth.guard.ts
+++ b/goblinhub-api/src/modules/supabase/guard/supabse-auth.guard.ts
@@ -1,0 +1,83 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+  Logger,
+} from '@nestjs/common';
+import { SupabaseValidationTokenService } from '../application/use-case/validationT.use-case';
+import {
+  SupabaseUser,
+  AuthenticatedRequest,
+} from '../interfaces/types/authenticated-request.interface';
+import { ValidationResult } from '../interfaces/types/validation-result.interface';
+
+@Injectable()
+export class SupabaseAuthGuard implements CanActivate {
+  private readonly logger = new Logger(SupabaseAuthGuard.name);
+
+  constructor(
+    private readonly validationTokenService: SupabaseValidationTokenService,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest<AuthenticatedRequest>();
+    const authHeader = request.headers.authorization;
+
+    if (!authHeader || typeof authHeader !== 'string') {
+      throw new UnauthorizedException(
+        'Authorization header is missing or invalid',
+      );
+    }
+
+    const token = authHeader.split(' ')[1]; // Assuming "Bearer <
+    if (!token) {
+      throw new UnauthorizedException(
+        'Token is missing from Authorization header',
+      );
+    }
+    try {
+      const result: ValidationResult =
+        await this.validationTokenService.validtoken(token);
+
+      if (result.success && result.user) {
+        request.user = result.user as SupabaseUser;
+        this.logger.log(
+          `token validated successfully for user: ${
+            result.user.email ?? result.user.id
+          }`,
+        );
+        return true;
+      }
+      throw new UnauthorizedException('Invalid token');
+    } catch (error: unknown) {
+      const errorMesage = this.extractErrorMessage(error);
+      this.logger.error(`Token validation failed: ${errorMesage}`);
+      throw new UnauthorizedException('Invalid token');
+    }
+  }
+
+  /**
+   * Extracts a meaningful error message from various error types.
+   */
+  private extractErrorMessage(error: unknown): string {
+    if (error instanceof Error) {
+      return error.message;
+    }
+
+    if (typeof error === 'string') {
+      return error;
+    }
+
+    if (
+      error &&
+      typeof error == 'object' &&
+      'message' in error &&
+      typeof (error as { message: unknown }).message === 'string'
+    ) {
+      return (error as { message: string }).message;
+    }
+
+    return 'Unknown error';
+  }
+}

--- a/goblinhub-api/src/modules/supabase/infrastructure/controller/supabase-auth.controller.ts
+++ b/goblinhub-api/src/modules/supabase/infrastructure/controller/supabase-auth.controller.ts
@@ -1,0 +1,109 @@
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  Post,
+  UnauthorizedException,
+  UseGuards,
+  Request,
+  HttpStatus,
+} from '@nestjs/common';
+import { SupabaseValidationTokenService } from '../../application/use-case/validationT.use-case';
+import { SupabaseRefreshTokenService } from '../../application/use-case/refreshT.use-case';
+import { SupabaseGetUserProfileService } from '../../application/use-case/getUserProfile.use-case';
+import { SupabaseCreateTestUserService } from '../../application/use-case/create-test-user.use-case';
+import {
+  CreateTesruserDto,
+  RefreshTokenDto,
+  SignInTestuserDto,
+  validateTokenDto,
+} from '../../application/dto/auth.dto';
+import { SupabaseAuthGuard } from '../../guard/supabse-auth.guard';
+import type { AuthenticatedRequest } from '../../interfaces/types/authenticated-request.interface';
+
+@Controller('auth')
+export class SupabaseAuthController {
+  constructor(
+    private readonly validationService: SupabaseValidationTokenService,
+    private readonly refreshService: SupabaseRefreshTokenService,
+    private readonly getUserProfileService: SupabaseGetUserProfileService,
+    private readonly createTestUserService: SupabaseCreateTestUserService,
+  ) {}
+
+  @Post('validate-token')
+  @HttpCode(HttpStatus.OK)
+  async validateToken(@Body() validateTokenDto: validateTokenDto) {
+    return await this.validationService.validtoken(validateTokenDto.token);
+  }
+
+  @Post('refresh-token')
+  @HttpCode(HttpStatus.OK)
+  async refreshToken(@Body() refreshTokenDto: RefreshTokenDto) {
+    return await this.refreshService.refreshToken(refreshTokenDto.refreshToken);
+  }
+
+  @Get('profile')
+  @UseGuards(SupabaseAuthGuard)
+  async getProfile(@Request() req: AuthenticatedRequest) {
+    if (!req.user) {
+      throw new UnauthorizedException('Usuario no autenticado');
+    }
+
+    const authHeader = req.headers.authorization;
+    if (!authHeader || typeof authHeader !== 'string') {
+      throw new UnauthorizedException('Token no encontrado en el header');
+    }
+
+    const token = authHeader.split(' ')[1];
+    if (!token) {
+      throw new UnauthorizedException('Token no encontrado');
+    }
+
+    return await this.getUserProfileService.getUserProfile(token);
+  }
+
+  @Get('verify')
+  @UseGuards(SupabaseAuthGuard)
+  verifyToken(@Request() req: AuthenticatedRequest) {
+    if (!req.user) {
+      throw new UnauthorizedException('Usuario no autenticado');
+    }
+
+    return {
+      success: true,
+      user: req.user,
+      message: 'Token valido y usuario autenticado',
+    };
+  }
+
+  @Post('test/signup')
+  @HttpCode(HttpStatus.CREATED)
+  async signUpTestUser(@Body() createTestUserDto: CreateTesruserDto) {
+    if (process.env.NODE_ENV === 'production') {
+      throw new UnauthorizedException('Not available in production');
+    }
+    return await this.createTestUserService.createTestUser(
+      createTestUserDto.email,
+      createTestUserDto.password,
+    );
+  }
+
+  @Post('test/signin')
+  @HttpCode(HttpStatus.OK)
+  async signInTestestuser(@Body() signInTestUserDto: SignInTestuserDto) {
+    if (process.env.NODE_ENV === 'production') {
+      throw new UnauthorizedException('Not available');
+    }
+    return await this.createTestUserService.signInTestuser(
+      signInTestUserDto.email,
+      signInTestUserDto.password,
+    );
+  }
+
+  //   @Get('test/users')
+  //   @HttpCode(HttpStatus.OK)
+  //   listTestUsers() {
+  //     return this.createTestUserService.listAuthUsers();
+  //   }
+}

--- a/goblinhub-api/src/modules/supabase/interfaces/types/authenticated-request.interface.ts
+++ b/goblinhub-api/src/modules/supabase/interfaces/types/authenticated-request.interface.ts
@@ -1,0 +1,30 @@
+import { Request } from 'express';
+
+export interface SupabaseUser {
+  id: string;
+  aud: string;
+  role: string;
+  email?: string;
+  email_confirmed_at?: string;
+  phone?: string;
+  phone_confirmed_at?: string;
+  last_sign_in_at?: string;
+  app_metadata: {
+    provider?: string;
+    providers?: string[];
+    [key: string]: any;
+  };
+  user_metadata: {
+    [key: string]: any;
+  };
+  identities?: any[];
+  created_at: string;
+  updated_at: string;
+}
+
+export interface AuthenticatedRequest extends Request {
+  user?: SupabaseUser;
+  headers: Request['headers'] & {
+    authorization?: string;
+  };
+}

--- a/goblinhub-api/src/modules/supabase/interfaces/types/validation-result.interface.ts
+++ b/goblinhub-api/src/modules/supabase/interfaces/types/validation-result.interface.ts
@@ -1,0 +1,7 @@
+import { User } from '@supabase/supabase-js';
+
+export interface ValidationResult {
+  success: boolean;
+  user: User;
+  message: string;
+}

--- a/goblinhub-api/src/modules/supabase/supabase-auth.module.ts
+++ b/goblinhub-api/src/modules/supabase/supabase-auth.module.ts
@@ -1,0 +1,28 @@
+import { Module } from '@nestjs/common';
+import { SupabaseModule } from './supabase.module';
+import { SupabaseAuthController } from './infrastructure/controller/supabase-auth.controller';
+import { SupabaseValidationTokenService } from './application/use-case/validationT.use-case';
+import { SupabaseGetUserProfileService } from './application/use-case/getUserProfile.use-case';
+import { SupabaseRefreshTokenService } from './application/use-case/refreshT.use-case';
+import { SupabaseCreateTestUserService } from './application/use-case/create-test-user.use-case';
+import { SupabaseAuthGuard } from './guard/supabse-auth.guard';
+
+@Module({
+  imports: [SupabaseModule],
+  controllers: [SupabaseAuthController],
+  providers: [
+    SupabaseValidationTokenService,
+    SupabaseGetUserProfileService,
+    SupabaseRefreshTokenService,
+    SupabaseCreateTestUserService,
+    SupabaseAuthController,
+    SupabaseAuthGuard,
+  ],
+  exports: [
+    SupabaseValidationTokenService,
+    SupabaseGetUserProfileService,
+    SupabaseRefreshTokenService,
+    SupabaseAuthGuard,
+  ],
+})
+export class SupabaseAuthModule {}

--- a/goblinhub-api/src/modules/supabase/supabase.module.ts
+++ b/goblinhub-api/src/modules/supabase/supabase.module.ts
@@ -1,0 +1,25 @@
+import { Global, Module } from '@nestjs/common';
+import { SupabaseClient } from '@supabase/supabase-js';
+
+@Global()
+@Module({
+  providers: [
+    {
+      provide: 'SUPABASE_CLIENT',
+      useFactory: (): SupabaseClient => {
+        const supabaseUrl = process.env.SUPABASE_URL;
+        const supabaseKey = process.env.SUPABASE_ANON_KEY;
+
+        if (!supabaseUrl || !supabaseKey) {
+          throw new Error(
+            'Supabase URL and Key must be set in environment variables',
+          );
+        }
+
+        return new SupabaseClient(supabaseUrl, supabaseKey);
+      },
+    },
+  ],
+  exports: ['SUPABASE_CLIENT'],
+})
+export class SupabaseModule {}


### PR DESCRIPTION
## 📌 Resumen del Cambio

Se integra Supabase Auth como proveedor de autenticación. Se crea el módulo `SupabaseAuthModule` con sus casos de uso, DTOs, guard y controlador. Además, se protegen los endpoints de mutación de eventos (`POST`, `PUT`, `DELETE`) con el guard de autenticación.

---

## 🔍 Tipo de Cambio realizado

Marca con una `x` lo que aplica:

- [ ] 🐞 Corrección de error (`fix`)
- [x] ✨ Nueva funcionalidad (`feat`)
- [ ] ♻️ Refactorización del código sin cambios funcionales (`refactor`)
- [ ] 🧪 Agregado o mejora de pruebas (`test`)
- [ ] 🧱 Cambio en configuración CI/CD (`ci`)
- [ ] 🚀 Mejora de rendimiento (`perf`)
- [ ] 📚 Cambios en la documentación (`docs`)
- [ ] Otro (especificar):

---

## 📂 Archivos Afectados

**Creados:**

- `goblinhub-api/src/modules/supabase/supabase.module.ts`
- `goblinhub-api/src/modules/supabase/supabase-auth.module.ts`
- `goblinhub-api/src/modules/supabase/application/dto/auth.dto.ts`
- `goblinhub-api/src/modules/supabase/application/use-case/validationT.use-case.ts`
- `goblinhub-api/src/modules/supabase/application/use-case/refreshT.use-case.ts`
- `goblinhub-api/src/modules/supabase/application/use-case/getUserProfile.use-case.ts`
- `goblinhub-api/src/modules/supabase/application/use-case/create-test-user.use-case.ts`
- `goblinhub-api/src/modules/supabase/guard/supabse-auth.guard.ts`
- `goblinhub-api/src/modules/supabase/infrastructure/controller/supabase-auth.controller.ts`
- `goblinhub-api/src/modules/supabase/interfaces/types/authenticated-request.interface.ts`
- `goblinhub-api/src/modules/supabase/interfaces/types/validation-result.interface.ts`

**Modificados:**

- `goblinhub-api/src/app.module.ts` — se registra `SupabaseAuthModule`
- `goblinhub-api/src/main.ts` — se configura CORS
- `goblinhub-api/src/modules/events/event.module.ts` — se importa `SupabaseAuthModule`
- `goblinhub-api/src/modules/events/interfaces/controllers/event.controller.ts` — se protegen endpoints de mutación

---

## 🧪 ¿Cómo Probarlo?

1. Configurar variables de entorno en `goblinhub-api/.env`:
   ```
   SUPABASE_URL=...
   SUPABASE_ANON_KEY=...
   CORS_ORIGIN=http://localhost:5173
   ```
2. Instalar dependencias: `npm install` dentro de `goblinhub-api/`
3. Iniciar el servidor: `npm run start:dev`
4. **Registro:** `POST /auth/test/signup` con `{ email, password }`
5. **Login:** `POST /auth/test/signin` con `{ email, password }` → obtener `access_token`
6. **Validar token:** `POST /auth/validate-token` con `{ token: "<access_token>" }`
7. **Perfil:** `GET /auth/profile` con header `Authorization: Bearer <access_token>`
8. **Protección de eventos:** intentar `POST /events` sin token → debe devolver `401`; con token válido → debe crear el evento

---

## ✅ Checklist

Asegúrate de completar lo siguiente antes de enviar:

- [x] He probado mis cambios localmente
- [x] Esta PR sigue el formato de convención de commits (si aplica)
- [ ] Se han actualizado o agregado pruebas
- [ ] La documentación se actualizó si fue necesario
- [ ] No hay errores en CI/CD

---

## 📎 Notas Adicionales

Resuelve el issue #15.

- El endpoint `POST /auth/test/signup` y `POST /auth/test/signin` están disponibles **solo en entornos no productivos** (`NODE_ENV !== 'production'`).
- El `SupabaseAuthGuard` valida el JWT directamente contra Supabase en cada request; no se almacenan sesiones en el backend.
- Pendiente para siguiente PR (#16): endpoint de registro completo que cree también el perfil en la tabla `usuarios` de forma atómica.

---

Gracias 🙌
