### PR TITLE
fix(bug): corregir scheduler que expiraba eventos con epoch 1970

### DIFF
--- a/goblinhub-api/src/modules/events/aplication/use-case/expire-events.use-case.ts
+++ b/goblinhub-api/src/modules/events/aplication/use-case/expire-events.use-case.ts
@@ -8,7 +8,7 @@ export class ExpireEventsUseCase {
   constructor(private readonly eventRepository: EventRepository) {}
 
   async execute(): Promise<void> {
-    const count = await this.eventRepository.expireEvents();
+    const count: number = await this.eventRepository.expireEvents();
 
     if (count > 0) {
       this.logger.log(`Soft-deleted ${count} expired event(s).`);

--- a/goblinhub-api/src/modules/events/infrastructure/prisma/event.repository.ts
+++ b/goblinhub-api/src/modules/events/infrastructure/prisma/event.repository.ts
@@ -240,16 +240,16 @@ export class EventRepositoryPrisma extends EventRepository {
 
   async expireEvents(): Promise<number> {
     const now = new Date();
+    // Start of today (midnight) to compare only against the event date
+    const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
 
-    // Soft-delete events where hora_fin has passed,
-    // or where hora_inicio has passed when hora_fin is not set.
+    // Soft-delete events whose fecha (event day) is strictly in the past.
+    // hora_inicio/hora_fin are stored as time-only values with a 1970 epoch
+    // date, so they cannot be used directly for expiration comparison.
     const result = await this.prisma.evento.updateMany({
       where: {
         deleted_at: null,
-        OR: [
-          { hora_fin: { lte: now } },
-          { hora_fin: null, hora_inicio: { lte: now } },
-        ],
+        fecha: { lt: today },
       },
       data: { deleted_at: now },
     });


### PR DESCRIPTION
Branch: fix/37-bug-scheduler-expira-eventos-por-hora_iniciohora_fin-con-epoch-1970
Fixes: #37

## 📌 Resumen del Cambio

Se corrige el método `expireEvents()` en el repositorio de eventos. La lógica anterior comparaba `hora_fin <= now()` para determinar si un evento había expirado, pero las columnas `hora_inicio` y `hora_fin` se almacenan como timestamps con fecha epoch `1970-01-01` (Prisma guarda solo la hora con esa fecha base), lo que hacía que **todos los eventos fueran soft-deleted al primer minuto** de ejecutar la aplicación, sin importar si su `fecha` real era futura.

La corrección cambia la comparación para basarse en el campo `fecha` (fecha real del evento), expirando solo eventos cuyo día de realización ya haya pasado.

---

## 🔍 Tipo de Cambio realizado

Marca con una `x` lo que aplica:

- [x] 🐞 Corrección de error (`fix`)
- [ ] ✨ Nueva funcionalidad (`feat`)
- [ ] ♻️ Refactorización del código sin cambios funcionales (`refactor`)
- [ ] 🧪 Agregado o mejora de pruebas (`test`)
- [ ] 🧱 Cambio en configuración CI/CD (`ci`)
- [ ] 🚀 Mejora de rendimiento (`perf`)
- [ ] 📚 Cambios en la documentación (`docs`)
- [ ] Otro (especificar):

---

## 📂 Archivos Afectados

- `goblinhub-api/src/modules/events/infrastructure/prisma/event.repository.ts`
- `goblinhub-api/src/modules/events/aplication/use-case/expire-events.use-case.ts`

---

## 🧪 ¿Cómo Probarlo?

1. Ejecutar `npm install` en `goblinhub-api/`
2. Iniciar la app con `npm run start:dev`
3. Crear un evento con `fecha` futura (ej. `2026-03-15`) y `hora_inicio` como hora-solamente (ej. `17:00:00`)
4. Esperar 1 minuto para que el scheduler ejecute `expireEvents()`
5. Hacer `GET /events` — el evento debe seguir apareciendo en la respuesta
6. Verificar en la BD que `deleted_at` sigue siendo `NULL` para ese evento

---

## ✅ Checklist

Asegúrate de completar lo siguiente antes de enviar:

- [x] He probado mis cambios localmente
- [x] Esta PR sigue el formato de convención de commits (si aplica)
- [ ] Se han actualizado o agregado pruebas
- [ ] La documentación se actualizó si fue necesario
- [ ] No hay errores en CI/CD

---

## 📎 Notas Adicionales

Este PR resuelve el issue #37.

**Acción necesaria en BD:** si los eventos ya fueron incorrectamente eliminados, restaurarlos ejecutando en Supabase SQL Editor:

```sql
UPDATE "evento" SET deleted_at = NULL WHERE fecha >= NOW();
```

---

Gracias 🙌
