### PR TITLE
feat(instalar): helmet instalado y configurado en main.ts

### DIFF
--- a/goblinhub-api/package-lock.json
+++ b/goblinhub-api/package-lock.json
@@ -22,6 +22,7 @@
         "@types/pg": "^8.16.0",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.3",
+        "helmet": "^8.1.0",
         "passport": "^0.7.0",
         "passport-jwt": "^4.0.1",
         "pg": "^8.18.0",
@@ -6778,6 +6779,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
+      "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/hono": {

--- a/goblinhub-api/package.json
+++ b/goblinhub-api/package.json
@@ -33,6 +33,7 @@
     "@types/pg": "^8.16.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.3",
+    "helmet": "^8.1.0",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
     "pg": "^8.18.0",

--- a/goblinhub-api/src/main.ts
+++ b/goblinhub-api/src/main.ts
@@ -9,6 +9,33 @@ async function bootstrap() {
   app.use(
     helmet({
       crossOriginResourcePolicy: { policy: 'cross-origin' },
+
+      // CSP básica para APIs
+      contentSecurityPolicy: {
+        directives: {
+          defaultSrc: ["'self'"],
+          connectSrc: ["'self'", 'https:'],
+          imgSrc: ["'self'", 'data:', 'https:'],
+          scriptSrc: ["'self'"],
+          styleSrc: ["'self'", "'unsafe-inline'"],
+        },
+      },
+
+      // Referrer policy (Observatory lo pide)
+      referrerPolicy: { policy: 'strict-origin-when-cross-origin' },
+
+      // HSTS (solo en producción)
+      strictTransportSecurity: {
+        maxAge: 15552000,
+        includeSubDomains: true,
+        preload: false,
+      },
+
+      // Frame protection
+      frameguard: { action: 'deny' },
+
+      // MIME sniff protection
+      noSniff: true,
     }),
   );
 

--- a/goblinhub-api/src/main.ts
+++ b/goblinhub-api/src/main.ts
@@ -1,9 +1,16 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { ValidationPipe } from '@nestjs/common';
+import helmet from 'helmet';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+
+  app.use(
+    helmet({
+      crossOriginResourcePolicy: { policy: 'cross-origin' },
+    }),
+  );
 
   app.enableCors({
     origin: process.env.CORS_ORIGIN?.split(',') ?? [],


### PR DESCRIPTION
Branch: feat/46-instalar-y-activar-helmet-en-la-api
Fixes: #46

# 🚀 Solicitud de Pull Request

Gracias por tu contribución. Por favor, completa la siguiente información para ayudar al equipo a revisar y aprobar este PR de manera eficiente.

---

## 📌 Resumen del Cambio

Se instala y configura el paquete `helmet` en la API de NestJS para agregar cabeceras HTTP de seguridad en todas las respuestas. Se configura `crossOriginResourcePolicy` con `cross-origin` para permitir el consumo de la API desde el frontend en otro dominio.

---

## 🔍 Tipo de Cambio realizado

Marca con una `x` lo que aplica:

- [ ] 🐞 Corrección de error (`fix`)
- [x] ✨ Nueva funcionalidad (`feat`)
- [ ] ♻️ Refactorización del código sin cambios funcionales (`refactor`)
- [ ] 🧪 Agregado o mejora de pruebas (`test`)
- [ ] 🧱 Cambio en configuración CI/CD (`ci`)
- [ ] 🚀 Mejora de rendimiento (`perf`)
- [ ] 📚 Cambios en la documentación (`docs`)
- [ ] Otro (especificar):

---

## 📂 Archivos Afectados

Enumera los archivos modificados o creados:

- `goblinhub-api/src/main.ts`

---

## 🧪 ¿Cómo Probarlo?

Incluye instrucciones claras para probar los cambios localmente.

1. Ingresar a `goblinhub-api` y ejecutar `npm install`
2. Levantar el servidor con `npm run start:dev`
3. Hacer cualquier request a la API (ej. `GET /`)
4. Verificar en los headers de la respuesta que aparecen cabeceras como `X-Frame-Options`, `X-Content-Type-Options`, `Strict-Transport-Security`, etc.

---

## ✅ Checklist

Asegúrate de completar lo siguiente antes de enviar:

- [x] He probado mis cambios localmente
- [x] Esta PR sigue el formato de convención de commits (si aplica)
- [ ] Se han actualizado o agregado pruebas
- [ ] La documentación se actualizó si fue necesario
- [ ] No hay errores en CI/CD

---

## 📎 Notas Adicionales

Este PR resuelve el issue #46.

Se usó la opción `crossOriginResourcePolicy: { policy: 'cross-origin' }` dentro de la llamada a `helmet()` para no sobreescribir la configuración por defecto del paquete. La configuración queda centralizada en una sola llamada antes de `enableCors()`.

https://docs.google.com/document/d/1UQEr9mGJVOn0c8VAk9TzrJW9L2q-GqMROyq0Mge0Tdg/edit?tab=t.0

---

Gracias 🙌
