### PR TITLE
Feat/48 script de respaldo y restauración automática de la base de datos

### DIFF
--- a/goblinhub-api/.gitignore
+++ b/goblinhub-api/.gitignore
@@ -56,3 +56,7 @@ pids
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 
 /generated/prisma
+
+# Database backups (pueden contener datos sensibles — no subir al repo)
+/backups/*.sql
+/backups/*.dump

--- a/goblinhub-api/backups/.gitkeep
+++ b/goblinhub-api/backups/.gitkeep
@@ -1,0 +1,3 @@
+# Los archivos de backup generados son ignorados por git.
+# Solo se versiona este archivo .gitkeep para mantener la carpeta en el repositorio.
+# Los backups pueden contener datos sensibles y no deben subirse al repositorio.

--- a/goblinhub-api/scripts/backup.bat
+++ b/goblinhub-api/scripts/backup.bat
@@ -1,0 +1,77 @@
+@echo off
+:: =============================================================
+:: GoblinHub — Script de Respaldo de Base de Datos (Windows)
+:: Uso: scripts\backup.bat
+:: Requiere: pg_dump en PATH y DATABASE_URL en .env
+:: =============================================================
+
+setlocal EnableDelayedExpansion
+
+:: Cargar variables desde .env si existe
+set "ENV_FILE=%~dp0..\.env"
+if exist "%ENV_FILE%" (
+  for /f "usebackq tokens=1,* delims==" %%A in ("%ENV_FILE%") do (
+    set "line=%%A"
+    if not "!line:~0,1!"=="#" (
+      if not "%%A"=="" (
+        set "%%A=%%B"
+      )
+    )
+  )
+)
+
+:: Validar DATABASE_URL
+if "%DATABASE_URL%"=="" (
+  echo [ERROR] La variable DATABASE_URL no esta definida.
+  echo         Asegurate de tener un archivo .env con DATABASE_URL configurado.
+  exit /b 1
+)
+
+:: Verificar que pg_dump este disponible
+where pg_dump >nul 2>&1
+if %errorlevel% neq 0 (
+  echo [ERROR] 'pg_dump' no esta instalado o no esta en el PATH.
+  echo         Descargalo desde: https://www.postgresql.org/download/windows/
+  exit /b 1
+)
+
+:: Crear carpeta backups si no existe
+set "BACKUP_DIR=%~dp0..\backups"
+if not exist "%BACKUP_DIR%" mkdir "%BACKUP_DIR%"
+
+:: Generar timestamp para el nombre del archivo
+for /f "tokens=1-3 delims=/" %%a in ("%DATE%") do (
+  set "DAY=%%a"
+  set "MON=%%b"
+  set "YR=%%c"
+)
+for /f "tokens=1-2 delims=:." %%a in ("%TIME: =0%") do (
+  set "HR=%%a"
+  set "MIN=%%b"
+)
+
+set "TIMESTAMP=%YR%-%MON%-%DAY%_%HR%-%MIN%"
+set "BACKUP_FILE=%BACKUP_DIR%\backup_%TIMESTAMP%.sql"
+
+echo Iniciando respaldo de la base de datos...
+echo Destino: %BACKUP_FILE%
+
+pg_dump ^
+  --dbname="%DATABASE_URL%" ^
+  --no-password ^
+  --format=plain ^
+  --no-owner ^
+  --no-acl ^
+  --file="%BACKUP_FILE%"
+
+if %errorlevel% equ 0 (
+  echo.
+  echo [OK] Respaldo completado exitosamente.
+  echo      Archivo: %BACKUP_FILE%
+) else (
+  echo.
+  echo [ERROR] El respaldo fallo. Revisa la conexion y las credenciales.
+  exit /b 1
+)
+
+endlocal

--- a/goblinhub-api/scripts/backup.sh
+++ b/goblinhub-api/scripts/backup.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# =============================================================
+# GoblinHub — Script de Respaldo de Base de Datos
+# Uso: ./scripts/backup.sh
+# Requiere: pg_dump instalado y variable DATABASE_URL en .env
+# =============================================================
+
+set -euo pipefail
+
+# Cargar variables del archivo .env si existe
+ENV_FILE="$(dirname "$0")/../.env"
+if [ -f "$ENV_FILE" ]; then
+  # Exporta solo las líneas que no son comentarios y no están vacías
+  set -o allexport
+  # shellcheck disable=SC1090
+  source "$ENV_FILE"
+  set +o allexport
+fi
+
+# Validar que DATABASE_URL esté definida
+if [ -z "${DATABASE_URL:-}" ]; then
+  echo "❌ Error: La variable DATABASE_URL no está definida."
+  echo "   Asegúrate de tener un archivo .env con DATABASE_URL configurado."
+  exit 1
+fi
+
+# Verificar que pg_dump esté disponible
+if ! command -v pg_dump &> /dev/null; then
+  echo "❌ Error: 'pg_dump' no está instalado o no está en el PATH."
+  echo "   Instálalo con: sudo apt install postgresql-client  (Ubuntu/Debian)"
+  echo "                  brew install libpq                   (macOS)"
+  exit 1
+fi
+
+# Crear carpeta de backups si no existe
+BACKUP_DIR="$(dirname "$0")/../backups"
+mkdir -p "$BACKUP_DIR"
+
+# Generar nombre de archivo con timestamp
+TIMESTAMP=$(date +"%Y-%m-%d_%H-%M-%S")
+BACKUP_FILE="$BACKUP_DIR/backup_$TIMESTAMP.sql"
+
+echo "🔄 Iniciando respaldo de la base de datos..."
+echo "   Destino: $BACKUP_FILE"
+
+# Ejecutar pg_dump usando la DATABASE_URL completa
+# --no-password evita el prompt interactivo (la contraseña viaja en la URL)
+# --format=plain genera un archivo SQL legible y restaurable con psql
+pg_dump \
+  --dbname="$DATABASE_URL" \
+  --no-password \
+  --format=plain \
+  --no-owner \
+  --no-acl \
+  --file="$BACKUP_FILE"
+
+echo "✅ Respaldo completado exitosamente."
+echo "   Archivo: $BACKUP_FILE"
+echo "   Tamaño: $(du -sh "$BACKUP_FILE" | cut -f1)"

--- a/goblinhub-api/scripts/restore.bat
+++ b/goblinhub-api/scripts/restore.bat
@@ -1,0 +1,85 @@
+@echo off
+:: =============================================================
+:: GoblinHub — Script de Restauracion de Base de Datos (Windows)
+:: Uso: scripts\restore.bat <ruta\al\backup.sql>
+:: Requiere: psql en PATH y DATABASE_URL en .env
+:: =============================================================
+
+setlocal EnableDelayedExpansion
+
+:: Validar argumento
+if "%~1"=="" (
+  echo [ERROR] Debes especificar el archivo de backup a restaurar.
+  echo         Uso: scripts\restore.bat ^<ruta\al\backup.sql^>
+  echo.
+  echo         Ejemplo: scripts\restore.bat backups\backup_2026-02-27_10-00.sql
+  exit /b 1
+)
+
+set "BACKUP_FILE=%~1"
+
+:: Verificar que el archivo existe
+if not exist "%BACKUP_FILE%" (
+  echo [ERROR] No se encontro el archivo '%BACKUP_FILE%'.
+  echo         Verifica la ruta e intenta de nuevo.
+  exit /b 1
+)
+
+:: Cargar variables desde .env si existe
+set "ENV_FILE=%~dp0..\.env"
+if exist "%ENV_FILE%" (
+  for /f "usebackq tokens=1,* delims==" %%A in ("%ENV_FILE%") do (
+    set "line=%%A"
+    if not "!line:~0,1!"=="#" (
+      if not "%%A"=="" (
+        set "%%A=%%B"
+      )
+    )
+  )
+)
+
+:: Validar DATABASE_URL
+if "%DATABASE_URL%"=="" (
+  echo [ERROR] La variable DATABASE_URL no esta definida.
+  echo         Asegurate de tener un archivo .env con DATABASE_URL configurado.
+  exit /b 1
+)
+
+:: Verificar que psql este disponible
+where psql >nul 2>&1
+if %errorlevel% neq 0 (
+  echo [ERROR] 'psql' no esta instalado o no esta en el PATH.
+  echo         Descargalo desde: https://www.postgresql.org/download/windows/
+  exit /b 1
+)
+
+echo ADVERTENCIA: Esta operacion sobreescribira datos existentes en la base de datos.
+echo Base de datos destino: %DATABASE_URL%
+echo Archivo de respaldo:   %BACKUP_FILE%
+echo.
+set /p CONFIRM="^¿Deseas continuar? (s/N): "
+
+if /i not "%CONFIRM%"=="s" (
+  echo Operacion cancelada.
+  exit /b 0
+)
+
+echo.
+echo Iniciando restauracion desde: %BACKUP_FILE%
+
+psql ^
+  --dbname="%DATABASE_URL%" ^
+  --no-password ^
+  --file="%BACKUP_FILE%" ^
+  --single-transaction
+
+if %errorlevel% equ 0 (
+  echo.
+  echo [OK] Restauracion completada exitosamente.
+) else (
+  echo.
+  echo [ERROR] La restauracion fallo. Revisa el archivo y la conexion.
+  exit /b 1
+)
+
+endlocal

--- a/goblinhub-api/scripts/restore.sh
+++ b/goblinhub-api/scripts/restore.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# =============================================================
+# GoblinHub — Script de Restauración de Base de Datos
+# Uso: ./scripts/restore.sh <ruta/al/archivo/backup.sql>
+# Requiere: psql instalado y variable DATABASE_URL en .env
+# =============================================================
+
+set -euo pipefail
+
+# Validar argumento
+if [ -z "${1:-}" ]; then
+  echo "❌ Error: Debes especificar el archivo de backup a restaurar."
+  echo "   Uso: ./scripts/restore.sh <ruta/al/backup.sql>"
+  echo ""
+  echo "   Ejemplo: ./scripts/restore.sh backups/backup_2026-02-27_10-00-00.sql"
+  exit 1
+fi
+
+BACKUP_FILE="$1"
+
+# Verificar que el archivo existe
+if [ ! -f "$BACKUP_FILE" ]; then
+  echo "❌ Error: No se encontró el archivo '$BACKUP_FILE'."
+  echo "   Verifica la ruta e intenta de nuevo."
+  exit 1
+fi
+
+# Cargar variables del archivo .env si existe
+ENV_FILE="$(dirname "$0")/../.env"
+if [ -f "$ENV_FILE" ]; then
+  set -o allexport
+  # shellcheck disable=SC1090
+  source "$ENV_FILE"
+  set +o allexport
+fi
+
+# Validar que DATABASE_URL esté definida
+if [ -z "${DATABASE_URL:-}" ]; then
+  echo "❌ Error: La variable DATABASE_URL no está definida."
+  echo "   Asegúrate de tener un archivo .env con DATABASE_URL configurado."
+  exit 1
+fi
+
+# Verificar que psql esté disponible
+if ! command -v psql &> /dev/null; then
+  echo "❌ Error: 'psql' no está instalado o no está en el PATH."
+  echo "   Instálalo con: sudo apt install postgresql-client  (Ubuntu/Debian)"
+  echo "                  brew install libpq                   (macOS)"
+  exit 1
+fi
+
+echo "⚠️  ADVERTENCIA: Esta operación sobreescribirá datos existentes en la base de datos."
+echo "   Base de datos destino: $DATABASE_URL"
+echo "   Archivo de respaldo:   $BACKUP_FILE"
+echo ""
+read -rp "¿Deseas continuar? (s/N): " CONFIRM
+
+if [[ "$CONFIRM" != "s" && "$CONFIRM" != "S" ]]; then
+  echo "Operación cancelada."
+  exit 0
+fi
+
+echo ""
+echo "🔄 Iniciando restauración desde: $BACKUP_FILE"
+
+psql \
+  --dbname="$DATABASE_URL" \
+  --no-password \
+  --file="$BACKUP_FILE" \
+  --single-transaction
+
+echo ""
+echo "✅ Restauración completada exitosamente."

--- a/goblinhub-api/src/app.module.ts
+++ b/goblinhub-api/src/app.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { EventModule } from './modules/events/event.module';
 import { ConfigModule } from '@nestjs/config';
 import { SupabaseAuthModule } from './modules/supabase/supabase-auth.module';
+import { BackupModule } from './modules/backup/backup.module';
 
 @Module({
   imports: [
@@ -10,6 +11,7 @@ import { SupabaseAuthModule } from './modules/supabase/supabase-auth.module';
     }),
     EventModule,
     SupabaseAuthModule,
+    BackupModule,
   ],
   controllers: [],
   providers: [],

--- a/goblinhub-api/src/modules/backup/backup.module.ts
+++ b/goblinhub-api/src/modules/backup/backup.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { BackupService } from './backup.service';
+import { BackupController } from './interfaces/backup.controller';
+import { BackupScheduler } from './infrastructure/backup.scheduler';
+import { SupabaseAuthModule } from '../supabase/supabase-auth.module';
+
+@Module({
+  imports: [
+    SupabaseAuthModule, // para poder usar SupabaseAuthGuard en el controller
+  ],
+  controllers: [BackupController],
+  providers: [BackupService, BackupScheduler],
+})
+export class BackupModule {}

--- a/goblinhub-api/src/modules/backup/backup.service.ts
+++ b/goblinhub-api/src/modules/backup/backup.service.ts
@@ -1,0 +1,169 @@
+import {
+  Injectable,
+  InternalServerErrorException,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { spawn } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+
+@Injectable()
+export class BackupService {
+  private readonly logger = new Logger(BackupService.name);
+  private readonly backupsDir: string;
+
+  constructor(private readonly configService: ConfigService) {
+    this.backupsDir = path.join(process.cwd(), 'backups');
+    // Crear carpeta si no existe al iniciar el servicio
+    if (!fs.existsSync(this.backupsDir)) {
+      fs.mkdirSync(this.backupsDir, { recursive: true });
+    }
+  }
+
+  // ──────────────────────────────────────────────
+  //  BACKUP
+  // ──────────────────────────────────────────────
+
+  async createBackup(): Promise<{
+    filename: string;
+    path: string;
+    sizeKb: number;
+  }> {
+    const databaseUrl = this.configService.get<string>('DATABASE_URL');
+    if (!databaseUrl) {
+      throw new InternalServerErrorException('DATABASE_URL is not configured');
+    }
+
+    const timestamp = this.getTimestamp();
+    const filename = `backup_${timestamp}.sql`;
+    const filepath = path.join(this.backupsDir, filename);
+
+    this.logger.log(`Starting database backup → ${filename}`);
+
+    await this.runCommand('pg_dump', [
+      `--dbname=${databaseUrl}`,
+      '--no-password',
+      '--format=plain',
+      '--no-owner',
+      '--no-acl',
+      `--file=${filepath}`,
+    ]);
+
+    const stats = fs.statSync(filepath);
+    const sizeKb = Math.round(stats.size / 1024);
+
+    this.logger.log(`Backup completed: ${filename} (${sizeKb} KB)`);
+    return { filename, path: filepath, sizeKb };
+  }
+
+  // ──────────────────────────────────────────────
+  //  RESTORE
+  // ──────────────────────────────────────────────
+
+  async restoreBackup(filename: string): Promise<{ message: string }> {
+    const databaseUrl = this.configService.get<string>('DATABASE_URL');
+    if (!databaseUrl) {
+      throw new InternalServerErrorException('DATABASE_URL is not configured');
+    }
+
+    // Validar que el nombre no contiene path traversal
+    const safeFilename = path.basename(filename);
+    const filepath = path.join(this.backupsDir, safeFilename);
+
+    if (!fs.existsSync(filepath)) {
+      throw new NotFoundException(`Backup file '${safeFilename}' not found`);
+    }
+
+    this.logger.warn(`Starting database restore from: ${safeFilename}`);
+
+    await this.runCommand('psql', [
+      `--dbname=${databaseUrl}`,
+      '--no-password',
+      `--file=${filepath}`,
+      '--single-transaction',
+    ]);
+
+    this.logger.log(`Restore completed from: ${safeFilename}`);
+    return { message: `Database restored successfully from '${safeFilename}'` };
+  }
+
+  // ──────────────────────────────────────────────
+  //  LISTAR BACKUPS
+  // ──────────────────────────────────────────────
+
+  listBackups(): {
+    filename: string;
+    createdAt: Date;
+    sizeKb: number;
+  }[] {
+    if (!fs.existsSync(this.backupsDir)) {
+      return [];
+    }
+
+    const files = fs
+      .readdirSync(this.backupsDir)
+      .filter((f) => f.endsWith('.sql') && f !== '.gitkeep');
+
+    return files
+      .map((filename) => {
+        const filepath = path.join(this.backupsDir, filename);
+        const stats = fs.statSync(filepath);
+        return {
+          filename,
+          createdAt: stats.birthtime,
+          sizeKb: Math.round(stats.size / 1024),
+        };
+      })
+      .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime()); // más recientes primero
+  }
+
+  // ──────────────────────────────────────────────
+  //  HELPERS PRIVADOS
+  // ──────────────────────────────────────────────
+
+  private getTimestamp(): string {
+    const now = new Date();
+    const pad = (n: number) => String(n).padStart(2, '0');
+    return (
+      `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}` +
+      `_${pad(now.getHours())}-${pad(now.getMinutes())}-${pad(now.getSeconds())}`
+    );
+  }
+
+  private runCommand(command: string, args: string[]): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const proc = spawn(command, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+
+      let stderr = '';
+      proc.stderr.on('data', (data: Buffer) => {
+        stderr += data.toString();
+      });
+
+      proc.on('close', (code) => {
+        if (code === 0) {
+          resolve();
+        } else {
+          this.logger.error(
+            `Command '${command}' failed (exit ${code}): ${stderr}`,
+          );
+          reject(
+            new InternalServerErrorException(
+              `'${command}' exited with code ${code}. Check server logs for details.`,
+            ),
+          );
+        }
+      });
+
+      proc.on('error', (err) => {
+        this.logger.error(`Failed to start '${command}': ${err.message}`);
+        reject(
+          new InternalServerErrorException(
+            `Could not start '${command}'. Make sure postgresql-client is installed.`,
+          ),
+        );
+      });
+    });
+  }
+}

--- a/goblinhub-api/src/modules/backup/dto/restore-backup.dto.ts
+++ b/goblinhub-api/src/modules/backup/dto/restore-backup.dto.ts
@@ -1,0 +1,10 @@
+import { IsString, Matches } from 'class-validator';
+
+export class RestoreBackupDto {
+  @IsString()
+  @Matches(/^backup_[\d]{4}-[\d]{2}-[\d]{2}_[\d]{2}-[\d]{2}-[\d]{2}\.sql$/, {
+    message:
+      'filename must be a valid backup file (e.g. backup_2026-02-27_02-00-00.sql)',
+  })
+  filename: string;
+}

--- a/goblinhub-api/src/modules/backup/infrastructure/backup.scheduler.ts
+++ b/goblinhub-api/src/modules/backup/infrastructure/backup.scheduler.ts
@@ -1,0 +1,27 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import { BackupService } from '../backup.service';
+
+@Injectable()
+export class BackupScheduler {
+  private readonly logger = new Logger(BackupScheduler.name);
+
+  constructor(private readonly backupService: BackupService) {}
+
+  /**
+   * Ejecuta un respaldo automático cada 24 horas (todos los días a las 02:00 AM).
+   * Usar EVERY_DAY_AT_2AM para producción minimiza impacto en horas pico.
+   */
+  @Cron('0 2 * * *', { name: 'daily-database-backup' })
+  async handleDailyBackup(): Promise<void> {
+    this.logger.log('⏰ Iniciando respaldo automático diario...');
+    try {
+      const result = await this.backupService.createBackup();
+      this.logger.log(
+        `✅ Respaldo automático completado: ${result.filename} (${result.sizeKb} KB)`,
+      );
+    } catch (error) {
+      this.logger.error('❌ El respaldo automático diario falló', error);
+    }
+  }
+}

--- a/goblinhub-api/src/modules/backup/interfaces/backup.controller.ts
+++ b/goblinhub-api/src/modules/backup/interfaces/backup.controller.ts
@@ -9,10 +9,14 @@ import {
 } from '@nestjs/common';
 import { BackupService } from '../backup.service';
 import { SupabaseAuthGuard } from '../../supabase/guard/supabse-auth.guard';
+import { RolesGuard } from '../../supabase/guard/roles.guard';
+import { Roles } from '../../supabase/guard/roles.decorator';
+import { RolUsuario } from '../../supabase/domain/enums/user.enum';
 import { RestoreBackupDto } from '../dto/restore-backup.dto';
 
 @Controller('backup')
-@UseGuards(SupabaseAuthGuard) // Todas las rutas requieren autenticación
+@UseGuards(SupabaseAuthGuard, RolesGuard) // Requiere JWT válido + rol admin
+@Roles(RolUsuario.admin)
 export class BackupController {
   constructor(private readonly backupService: BackupService) {}
 

--- a/goblinhub-api/src/modules/backup/interfaces/backup.controller.ts
+++ b/goblinhub-api/src/modules/backup/interfaces/backup.controller.ts
@@ -1,0 +1,61 @@
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import { BackupService } from '../backup.service';
+import { SupabaseAuthGuard } from '../../supabase/guard/supabse-auth.guard';
+import { RestoreBackupDto } from '../dto/restore-backup.dto';
+
+@Controller('backup')
+@UseGuards(SupabaseAuthGuard) // Todas las rutas requieren autenticación
+export class BackupController {
+  constructor(private readonly backupService: BackupService) {}
+
+  /**
+   * GET /backup
+   * Lista todos los archivos de backup disponibles, ordenados del más reciente al más antiguo.
+   */
+  @Get()
+  @HttpCode(HttpStatus.OK)
+  listBackups() {
+    const backups = this.backupService.listBackups();
+    return {
+      success: true,
+      count: backups.length,
+      backups,
+    };
+  }
+
+  /**
+   * POST /backup
+   * Dispara un respaldo manual de forma inmediata.
+   */
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  async createBackup() {
+    const result = await this.backupService.createBackup();
+    return {
+      success: true,
+      message: 'Backup created successfully',
+      ...result,
+    };
+  }
+
+  /**
+   * POST /backup/restore
+   * Restaura la base de datos desde el archivo de backup indicado.
+   * Body: { "filename": "backup_2026-02-27_02-00-00.sql" }
+   *
+   * ⚠️ Operación destructiva: sobreescribe los datos actuales.
+   */
+  @Post('restore')
+  @HttpCode(HttpStatus.OK)
+  async restoreBackup(@Body() dto: RestoreBackupDto) {
+    return await this.backupService.restoreBackup(dto.filename);
+  }
+}

--- a/goblinhub-api/src/modules/supabase/guard/roles.decorator.ts
+++ b/goblinhub-api/src/modules/supabase/guard/roles.decorator.ts
@@ -1,0 +1,5 @@
+import { SetMetadata } from '@nestjs/common';
+import { RolUsuario } from '../domain/enums/user.enum';
+
+export const ROLES_KEY = 'roles';
+export const Roles = (...roles: RolUsuario[]) => SetMetadata(ROLES_KEY, roles);

--- a/goblinhub-api/src/modules/supabase/guard/roles.guard.ts
+++ b/goblinhub-api/src/modules/supabase/guard/roles.guard.ts
@@ -1,0 +1,54 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Injectable,
+  Logger,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { UsuarioRepository } from '../domain/repositories/usuario.repository';
+import { RolUsuario } from '../domain/enums/user.enum';
+import { ROLES_KEY } from './roles.decorator';
+import { AuthenticatedRequest } from '../interfaces/types/authenticated-request.interface';
+
+@Injectable()
+export class RolesGuard implements CanActivate {
+  private readonly logger = new Logger(RolesGuard.name);
+
+  constructor(
+    private readonly reflector: Reflector,
+    private readonly usuarioRepository: UsuarioRepository,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const requiredRoles = this.reflector.getAllAndOverride<RolUsuario[]>(
+      ROLES_KEY,
+      [context.getHandler(), context.getClass()],
+    );
+
+    // Si la ruta no tiene @Roles(), se permite el acceso
+    if (!requiredRoles || requiredRoles.length === 0) {
+      return true;
+    }
+
+    const request = context.switchToHttp().getRequest<AuthenticatedRequest>();
+    const userId = request.user?.id;
+
+    if (!userId) {
+      throw new ForbiddenException('User identity not found in request');
+    }
+
+    const rol = await this.usuarioRepository.findRolById(userId);
+
+    if (!rol || !requiredRoles.includes(rol)) {
+      this.logger.warn(
+        `Access denied for user ${userId} — required: [${requiredRoles.join(', ')}], has: ${rol ?? 'none'}`,
+      );
+      throw new ForbiddenException(
+        'You do not have permission to perform this action',
+      );
+    }
+
+    return true;
+  }
+}

--- a/goblinhub-api/src/modules/supabase/supabase-auth.module.ts
+++ b/goblinhub-api/src/modules/supabase/supabase-auth.module.ts
@@ -9,6 +9,7 @@ import { SupabaseCreateTestUserService } from './application/use-case/login-user
 import { SupabaseRegisterUserService } from './application/use-case/register-user.use-case';
 import { GetMeUseCase } from './application/use-case/getMe.use-case';
 import { SupabaseAuthGuard } from './guard/supabse-auth.guard';
+import { RolesGuard } from './guard/roles.guard';
 import { UsuarioRepository } from './domain/repositories/usuario.repository';
 import { UsuarioRepositoryPrisma } from './infrastructure/prisma/usuario.repository';
 
@@ -24,6 +25,7 @@ import { UsuarioRepositoryPrisma } from './infrastructure/prisma/usuario.reposit
     GetMeUseCase,
     SupabaseAuthController,
     SupabaseAuthGuard,
+    RolesGuard,
     {
       provide: UsuarioRepository,
       useClass: UsuarioRepositoryPrisma,
@@ -34,6 +36,7 @@ import { UsuarioRepositoryPrisma } from './infrastructure/prisma/usuario.reposit
     SupabaseGetUserProfileService,
     SupabaseRefreshTokenService,
     SupabaseAuthGuard,
+    RolesGuard,
     UsuarioRepository,
   ],
 })


### PR DESCRIPTION
# 🚀 Solicitud de Pull Request

Gracias por tu contribución. Por favor, completa la siguiente información para ayudar al equipo a revisar y aprobar este PR de manera eficiente.

---

## 📌 Resumen del Cambio

Se implementa un sistema completo de **respaldo y restauración automática de la base de datos PostgreSQL (Supabase)**. El sistema opera en dos modos: automático mediante un scheduler que ejecuta un backup diario a las 02:00 AM sin intervención humana, y manual mediante endpoints HTTP protegidos que permiten generar backups, listarlos y restaurar la base de datos sin salir de la aplicación. Además, se crean scripts de terminal (`.sh` y `.bat`) para operar en escenarios donde el servidor esté caído. Todos los endpoints de backup están restringidos exclusivamente al rol `admin`.

---

## 🔍 Tipo de Cambio realizado

Marca con una `x` lo que aplica:

- [ ] 🐞 Corrección de error (`fix`)
- [x] ✨ Nueva funcionalidad (`feat`)
- [ ] ♻️ Refactorización del código sin cambios funcionales (`refactor`)
- [ ] 🧪 Agregado o mejora de pruebas (`test`)
- [ ] 🧱 Cambio en configuración CI/CD (`ci`)
- [ ] 🚀 Mejora de rendimiento (`perf`)
- [ ] 📚 Cambios en la documentación (`docs`)
- [ ] Otro (especificar):

---

## 📂 Archivos Afectados

**Módulo de backup (nuevos):**

- `src/modules/backup/backup.service.ts` — lógica central: ejecuta `pg_dump` y `psql`, lista archivos
- `src/modules/backup/infrastructure/backup.scheduler.ts` — cron job diario a las 02:00 AM
- `src/modules/backup/interfaces/backup.controller.ts` — endpoints HTTP (`GET /backup`, `POST /backup`, `POST /backup/restore`)
- `src/modules/backup/dto/restore-backup.dto.ts` — DTO con validación regex del nombre de archivo
- `src/modules/backup/backup.module.ts` — registra todos los componentes del módulo

**Guards de roles (nuevos):**

- `src/modules/supabase/guard/roles.guard.ts` — guard que consulta el rol del usuario en Prisma
- `src/modules/supabase/guard/roles.decorator.ts` — decorador `@Roles()` para marcar rutas por rol

**Scripts de terminal (nuevos):**

- `scripts/backup.sh` / `scripts/backup.bat` — genera un backup desde la terminal
- `scripts/restore.sh` / `scripts/restore.bat` — restaura la BD desde un archivo `.sql`
- `backups/.gitkeep` — mantiene la carpeta en el repo sin subir archivos SQL

**Modificados:**

- `src/app.module.ts` — registra `BackupModule`
- `src/modules/supabase/supabase-auth.module.ts` — exporta `RolesGuard`
- `.gitignore` — ignora `backups/*.sql` y `backups/*.dump`
- `README.md` — documenta el uso de los scripts y endpoints

---

## 🧪 ¿Cómo Probarlo?

**Requisitos previos:**

- `pg_dump` y `psql` instalados (`sudo apt install postgresql-client`)
- Backend corriendo con `DATABASE_URL` configurado en `.env`
- Usuario con rol `admin` en la tabla `usuarios`

**Backup manual vía HTTP:**

```bash
# 1. Obtener token de un usuario admin
POST /auth/signin  →  { access_token: "..." }

# 2. Generar backup
POST /backup
Authorization: Bearer <token>

# 3. Listar backups disponibles
GET /backup
Authorization: Bearer <token>
```

**Restauración vía HTTP:**

```bash
POST /backup/restore
Authorization: Bearer <token>
Content-Type: application/json

{ "filename": "backup_2026-02-27_02-00-00.sql" }
```

**Scripts de terminal:**

```bash
./scripts/backup.sh          # genera backup en backups/
./scripts/restore.sh backups/backup_2026-02-27_02-00-00.sql
```

**Verificar scheduler automático:**

- Revisar logs del servidor a las 02:00 AM: debe aparecer `✅ Respaldo automático completado`

**Verificar restricción de rol:**

- Intentar `POST /backup` con un usuario de rol `jugador` → debe retornar `403 Forbidden`

---

## ✅ Checklist

Asegúrate de completar lo siguiente antes de enviar:

- [x] He probado mis cambios localmente
- [x] Esta PR sigue el formato de convención de commits (si aplica)
- [ ] Se han actualizado o agregado pruebas
- [x] La documentación se actualizó si fue necesario
- [x] No hay errores en CI/CD

---

## 📎 Notas Adicionales

- Este PR resuelve el issue **#48**
- Los archivos `.sql` generados están excluidos del repositorio vía `.gitignore` para evitar exponer datos sensibles
- La restauración usa `--single-transaction` en `psql`, garantizando que si algo falla durante la restauración toda la operación se revierte (atomicidad total)
- El nombre del archivo de restauración es sanitizado con `path.basename()` para prevenir ataques de path traversal
- El `RolesGuard` creado en este PR es reutilizable para proteger cualquier otro endpoint por rol en el futuro

---

Gracias 🙌
