### PR TITLE
Feat/92 recuperación de contraseña olvidada backend

### DIFF
--- a/goblinhub-api/.env.example
+++ b/goblinhub-api/.env.example
@@ -6,5 +6,7 @@ DATABASE_URL=postgresql://usuario:contrasena@host:5432/nombre_bd?schema=public
 
 SUPABASE_ANON_KEY=tu_supabase_anon_key_aqui
 SUPABASE_URL=https://tu_proyecto.supabase.co
+SUPABASE_SERVICE_ROLE_KEY=tu_supabase_service_role_key_aqui
+SUPABASE_RESET_PASSWORD_URL=http://localhost:5173/reset-password
 
 PORT=3000

--- a/goblinhub-api/src/modules/events/application/use-case/expire-events.use-case.spec.ts
+++ b/goblinhub-api/src/modules/events/application/use-case/expire-events.use-case.spec.ts
@@ -20,14 +20,14 @@ describe('ExpireEventsUseCase', () => {
 
   it('debe hacer log si hay eventos', async () => {
     eventRepo.expireEvents.mockResolvedValue(5);
-    await useCase.execute();
+    await useCase.expireAndSoftDeleteEvents();
     // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(eventRepo.expireEvents).toHaveBeenCalledTimes(1);
   });
 
   it('no debe hacer log si es 0', async () => {
     eventRepo.expireEvents.mockResolvedValue(0);
-    await useCase.execute();
+    await useCase.expireAndSoftDeleteEvents();
     // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(eventRepo.expireEvents).toHaveBeenCalledTimes(1);
   });

--- a/goblinhub-api/src/modules/events/application/use-case/expire-events.use-case.ts
+++ b/goblinhub-api/src/modules/events/application/use-case/expire-events.use-case.ts
@@ -7,7 +7,7 @@ export class ExpireEventsUseCase {
 
   constructor(private readonly eventRepository: EventRepository) {}
 
-  async execute(): Promise<void> {
+  async expireAndSoftDeleteEvents(): Promise<void> {
     const count: number = await this.eventRepository.expireEvents();
 
     if (count > 0) {

--- a/goblinhub-api/src/modules/events/infrastructure/scheduler/event-expiration.scheduler.ts
+++ b/goblinhub-api/src/modules/events/infrastructure/scheduler/event-expiration.scheduler.ts
@@ -12,6 +12,6 @@ export class EventExpirationScheduler {
   @Cron(CronExpression.EVERY_MINUTE)
   async handleExpiredEvents(): Promise<void> {
     this.logger.debug('Checking for expired events...');
-    await this.expireEventsUseCase.execute();
+    await this.expireEventsUseCase.expireAndSoftDeleteEvents();
   }
 }

--- a/goblinhub-api/src/modules/rewards/aplication/use-case/create-reward.use-case.spec.ts
+++ b/goblinhub-api/src/modules/rewards/aplication/use-case/create-reward.use-case.spec.ts
@@ -49,7 +49,10 @@ describe('CreateRewardUseCase', () => {
     rewardRepo.findByName.mockResolvedValue(null);
     rewardRepo.create.mockResolvedValue(mockCreatedReward);
 
-    const result = await useCase.execute(mockDto, 'admin-uuid');
+    const result: Recompensa = await useCase.createReward(
+      mockDto,
+      'admin-uuid',
+    );
 
     expect(result.id).toBe(1);
     // eslint-disable-next-line @typescript-eslint/unbound-method
@@ -59,7 +62,7 @@ describe('CreateRewardUseCase', () => {
   it('debe lanzar ForbiddenException si el usuario no tiene permisos', async () => {
     userRepo.findRolById.mockResolvedValue(null);
 
-    await expect(useCase.execute(mockDto, 'user-uuid')).rejects.toThrow(
+    await expect(useCase.createReward(mockDto, 'user-uuid')).rejects.toThrow(
       ForbiddenException,
     );
   });
@@ -76,7 +79,7 @@ describe('CreateRewardUseCase', () => {
       ),
     );
 
-    await expect(useCase.execute(mockDto, 'emp-uuid')).rejects.toThrow(
+    await expect(useCase.createReward(mockDto, 'emp-uuid')).rejects.toThrow(
       HttpException,
     );
   });
@@ -90,16 +93,16 @@ describe('CreateRewardUseCase', () => {
       tipo: 'TIPO_INVENTADO' as TipoRecompensa,
     };
 
-    await expect(useCase.execute(invalidDto, 'admin-uuid')).rejects.toThrow(
-      HttpException,
-    );
+    await expect(
+      useCase.createReward(invalidDto, 'admin-uuid'),
+    ).rejects.toThrow(HttpException);
   });
 
   it('debe lanzar HttpException 500 ante un error inesperado del repositorio', async () => {
     userRepo.findRolById.mockResolvedValue(RolUsuario.admin);
     rewardRepo.findByName.mockRejectedValue(new Error('Fallo total de DB'));
 
-    await expect(useCase.execute(mockDto, 'admin-uuid')).rejects.toThrow(
+    await expect(useCase.createReward(mockDto, 'admin-uuid')).rejects.toThrow(
       HttpException,
     );
   });
@@ -110,7 +113,8 @@ describe('CreateRewardUseCase', () => {
     );
 
     try {
-      await useCase.execute(mockDto, 'admin-uuid');
+      await useCase.createReward(mockDto, 'admin-uuid');
+      fail('should have thrown');
     } catch (e) {
       expect(e).toBeInstanceOf(HttpException);
       expect((e as HttpException).getStatus()).toBe(418);

--- a/goblinhub-api/src/modules/rewards/aplication/use-case/create-reward.use-case.ts
+++ b/goblinhub-api/src/modules/rewards/aplication/use-case/create-reward.use-case.ts
@@ -13,7 +13,7 @@ export class CreateRewardUseCase {
     private usuarioRepository: UsuarioRepository,
   ) {}
 
-  async execute(
+  async createReward(
     data: CreateRecompensaDto,
     id_creador: string,
   ): Promise<Recompensa> {

--- a/goblinhub-api/src/modules/rewards/interfaces/controllers/reward.controller.ts
+++ b/goblinhub-api/src/modules/rewards/interfaces/controllers/reward.controller.ts
@@ -85,7 +85,7 @@ export class RewardController {
   ): Promise<Recompensa> {
     if (!req.user) throw new UnauthorizedException('User not authenticated');
 
-    return await this.createUseCase.execute(createRewardDto, req.user.id);
+    return await this.createUseCase.createReward(createRewardDto, req.user.id);
   }
 
   @Patch(':id')

--- a/goblinhub-api/src/modules/supabase/application/dto/auth.dto.ts
+++ b/goblinhub-api/src/modules/supabase/application/dto/auth.dto.ts
@@ -72,3 +72,21 @@ export class RegisterUserDto {
   @IsEnum(NivelExperiencia)
   nivel_experiencia?: NivelExperiencia;
 }
+
+export class ForgotPasswordDto {
+  @IsEmail()
+  email: string;
+}
+
+export class ResetPasswordDto {
+  @IsString()
+  accessToken: string;
+
+  @IsString()
+  @MinLength(8)
+  newPassword: string;
+
+  @IsString()
+  @MinLength(8)
+  confirmPassword: string;
+}

--- a/goblinhub-api/src/modules/supabase/application/use-case/forgot-password.use-case.ts
+++ b/goblinhub-api/src/modules/supabase/application/use-case/forgot-password.use-case.ts
@@ -1,0 +1,19 @@
+import { BadRequestException, Inject, Injectable } from '@nestjs/common';
+import { SupabaseClient } from '@supabase/supabase-js';
+
+@Injectable()
+export class ForgotPasswordUseCase {
+  constructor(
+    @Inject('SUPABASE_CLIENT') private readonly supabase: SupabaseClient,
+  ) {}
+
+  async forgotPassword(email: string) {
+    const { error } = await this.supabase.auth.resetPasswordForEmail(email, {
+      redirectTo: process.env.SUPABASE_RESET_PASSWORD_URL,
+    });
+    if (error) {
+      throw new BadRequestException(error.message);
+    }
+    return { message: 'Correo de recuperación enviado' };
+  }
+}

--- a/goblinhub-api/src/modules/supabase/application/use-case/getMe.use-case.ts
+++ b/goblinhub-api/src/modules/supabase/application/use-case/getMe.use-case.ts
@@ -15,7 +15,7 @@ export interface MeResult {
 export class GetMeUseCase {
   constructor(private readonly usuarioRepository: UsuarioRepository) {}
 
-  async execute(id: string, email: string | undefined): Promise<MeResult> {
+  async getMyProfile(id: string, email: string | undefined): Promise<MeResult> {
     const perfil: UsuarioPerfil | null =
       await this.usuarioRepository.findProfileById(id);
 

--- a/goblinhub-api/src/modules/supabase/application/use-case/getUserProfile.use-case.ts
+++ b/goblinhub-api/src/modules/supabase/application/use-case/getUserProfile.use-case.ts
@@ -36,6 +36,7 @@ export class SupabaseGetUserProfileService {
       if (error instanceof UnauthorizedException) {
         throw error;
       }
+      throw new UnauthorizedException('Failed to retrieve user profile');
     }
   }
 }

--- a/goblinhub-api/src/modules/supabase/application/use-case/reset-password.use-case.ts
+++ b/goblinhub-api/src/modules/supabase/application/use-case/reset-password.use-case.ts
@@ -1,0 +1,61 @@
+import {
+  BadRequestException,
+  Inject,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+
+@Injectable()
+export class ResetPasswordUseCase {
+  constructor(
+    @Inject('SUPABASE_ADMIN_CLIENT')
+    private readonly supabaseAdmin: SupabaseClient,
+  ) {}
+
+  async resetPassword(
+    accessToken: string,
+    newPassword: string,
+    confirmPassword: string,
+  ) {
+    if (newPassword !== confirmPassword) {
+      throw new BadRequestException('Las contraseñas no coinciden');
+    }
+
+    const supabaseUrl = process.env.SUPABASE_URL;
+    const supabaseAnonKey = process.env.SUPABASE_ANON_KEY;
+
+    if (!supabaseUrl || !supabaseAnonKey) {
+      throw new BadRequestException('Configuración de Supabase incompleta');
+    }
+
+    // Paso 1: usar el anon client para validar el recovery JWT.
+    // supabase.auth.getUser(jwt) envía GET /auth/v1/user con
+    // Authorization: Bearer <jwt> — funciona correctamente con tokens de recovery.
+    const anonClient = createClient(supabaseUrl, supabaseAnonKey, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    });
+
+    const {
+      data: { user },
+      error: getUserError,
+    } = await anonClient.auth.getUser(accessToken);
+
+    if (getUserError || !user) {
+      throw new UnauthorizedException('Token inválido o expirado');
+    }
+
+    // Paso 2: actualizar la contraseña con el admin client.
+    // Esta es la única vía 100% confiable desde un backend NestJS.
+    const { error: updateError } =
+      await this.supabaseAdmin.auth.admin.updateUserById(user.id, {
+        password: newPassword,
+      });
+
+    if (updateError) {
+      throw new BadRequestException(updateError.message);
+    }
+
+    return { message: 'Contraseña actualizada correctamente' };
+  }
+}

--- a/goblinhub-api/src/modules/supabase/application/use-case/signin.use-case.ts
+++ b/goblinhub-api/src/modules/supabase/application/use-case/signin.use-case.ts
@@ -12,7 +12,10 @@ export class SignInUseCase {
     @Inject('SUPABASE_CLIENT') private readonly supabase: SupabaseClient,
   ) {}
 
-  async execute(email: string, password: string): Promise<SignInResult> {
+  async signInWithCredentials(
+    email: string,
+    password: string,
+  ): Promise<SignInResult> {
     const { data, error } = await this.supabase.auth.signInWithPassword({
       email,
       password,

--- a/goblinhub-api/src/modules/supabase/infrastructure/controller/supabase-auth.controller.ts
+++ b/goblinhub-api/src/modules/supabase/infrastructure/controller/supabase-auth.controller.ts
@@ -17,13 +17,17 @@ import { SupabaseRegisterUserService } from '../../application/use-case/register
 import { GetMeUseCase } from '../../application/use-case/getMe.use-case';
 import { SignInUseCase } from '../../application/use-case/signin.use-case';
 import {
+  ForgotPasswordDto,
   RefreshTokenDto,
   RegisterUserDto,
+  ResetPasswordDto,
   SignInDto,
   SignInTestuserDto,
 } from '../../application/dto/auth.dto';
 import { SupabaseAuthGuard } from '../../guard/supabse-auth.guard';
 import type { AuthenticatedRequest } from '../../interfaces/types/authenticated-request.interface';
+import { ForgotPasswordUseCase } from '../../application/use-case/forgot-password.use-case';
+import { ResetPasswordUseCase } from '../../application/use-case/reset-password.use-case';
 
 @Controller('auth')
 export class SupabaseAuthController {
@@ -35,13 +39,18 @@ export class SupabaseAuthController {
     private readonly registerUserService: SupabaseRegisterUserService,
     private readonly getMeUseCase: GetMeUseCase,
     private readonly signInUseCase: SignInUseCase,
+    private readonly forgotPasswordUseCase: ForgotPasswordUseCase,
+    private readonly resetPasswordUseCase: ResetPasswordUseCase,
   ) {}
 
   /** Endpoint de login limpio — solo devuelve access_token y refresh_token */
   @Post('signin')
   @HttpCode(HttpStatus.OK)
   async signIn(@Body() dto: SignInDto) {
-    return await this.signInUseCase.execute(dto.email, dto.password);
+    return await this.signInUseCase.signInWithCredentials(
+      dto.email,
+      dto.password,
+    );
   }
 
   @Post('signup')
@@ -82,7 +91,7 @@ export class SupabaseAuthController {
     if (!req.user) throw new UnauthorizedException('User not authenticated');
     const id: string = req.user.id;
     const email: string | undefined = req.user.email;
-    return this.getMeUseCase.execute(id, email);
+    return this.getMeUseCase.getMyProfile(id, email);
   }
 
   @Get('verify')
@@ -97,6 +106,22 @@ export class SupabaseAuthController {
       user: req.user,
       message: 'Token valid and user authenticated',
     };
+  }
+
+  @Post('forgot-password')
+  @HttpCode(HttpStatus.OK)
+  async forgotPassword(@Body() dto: ForgotPasswordDto) {
+    return await this.forgotPasswordUseCase.forgotPassword(dto.email);
+  }
+
+  @Post('reset-password')
+  @HttpCode(HttpStatus.OK)
+  async resetPassword(@Body() dto: ResetPasswordDto) {
+    return await this.resetPasswordUseCase.resetPassword(
+      dto.accessToken,
+      dto.newPassword,
+      dto.confirmPassword,
+    );
   }
 
   /** Solo para desarrollo/testing interno — bloqueado en producción */

--- a/goblinhub-api/src/modules/supabase/supabase-auth.module.ts
+++ b/goblinhub-api/src/modules/supabase/supabase-auth.module.ts
@@ -9,6 +9,8 @@ import { SupabaseCreateTestUserService } from './application/use-case/login-user
 import { SupabaseRegisterUserService } from './application/use-case/register-user.use-case';
 import { GetMeUseCase } from './application/use-case/getMe.use-case';
 import { SignInUseCase } from './application/use-case/signin.use-case';
+import { ForgotPasswordUseCase } from './application/use-case/forgot-password.use-case';
+import { ResetPasswordUseCase } from './application/use-case/reset-password.use-case';
 import { SupabaseAuthGuard } from './guard/supabse-auth.guard';
 import { RolesGuard } from './guard/roles.guard';
 import { UsuarioRepository } from './domain/repositories/usuario.repository';
@@ -25,6 +27,8 @@ import { UsuarioRepositoryPrisma } from './infrastructure/prisma/usuario.reposit
     SupabaseRegisterUserService,
     GetMeUseCase,
     SignInUseCase,
+    ForgotPasswordUseCase,
+    ResetPasswordUseCase,
     SupabaseAuthGuard,
     RolesGuard,
     {

--- a/goblinhub-api/src/modules/supabase/supabase.module.ts
+++ b/goblinhub-api/src/modules/supabase/supabase.module.ts
@@ -1,5 +1,5 @@
 import { Global, Module } from '@nestjs/common';
-import { SupabaseClient } from '@supabase/supabase-js';
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
 
 @Global()
 @Module({
@@ -19,7 +19,24 @@ import { SupabaseClient } from '@supabase/supabase-js';
         return new SupabaseClient(supabaseUrl, supabaseKey);
       },
     },
+    {
+      provide: 'SUPABASE_ADMIN_CLIENT',
+      useFactory: () => {
+        const supabaseUrl = process.env.SUPABASE_URL;
+        const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+        if (!supabaseUrl || !serviceRoleKey) {
+          throw new Error(
+            'Supabase URL and Service Role Key must be set in environment variables',
+          );
+        }
+
+        return createClient(supabaseUrl, serviceRoleKey, {
+          auth: { autoRefreshToken: false, persistSession: false },
+        });
+      },
+    },
   ],
-  exports: ['SUPABASE_CLIENT'],
+  exports: ['SUPABASE_CLIENT', 'SUPABASE_ADMIN_CLIENT'],
 })
 export class SupabaseModule {}

--- a/goblinhub_web/src/App.tsx
+++ b/goblinhub_web/src/App.tsx
@@ -11,7 +11,7 @@ import Login from "./pages/login/Login";
 import RegisterFlow from "./pages/register/RegisterFlow";
 import AuthHome from "./pages/Home/Home";
 import PerfilPage from "./pages/perfil/PerfilPage";
-
+import ResetPassword from "./pages/resetPassword/ResetPassword";
 
 function App() {
   return (
@@ -27,6 +27,7 @@ function App() {
         <Route path="/eventos/:id" element={<EventoDetalle />} />
         <Route path="/register" element={<RegisterFlow />} />
         <Route path="/login" element={<Login />} />
+        <Route path="/reset-password" element={<ResetPassword />} />
 
         {/* Rutas protegidas (requieren JWT) */}
         <Route element={<ProtectedRoute />}>

--- a/goblinhub_web/src/pages/login/Login.tsx
+++ b/goblinhub_web/src/pages/login/Login.tsx
@@ -2,15 +2,36 @@ import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import axios from "axios";
 import "./Login.css";
-import { login } from "../../services/auth.service";
+import {
+  login,
+  forgotPassword as sendForgotPassword,
+} from "../../services/auth.service";
 
 const Login: React.FC = () => {
   const [forgotPassword, setForgotPassword] = useState(false);
   const [email, setEmail] = useState("");
+  const [forgotEmail, setForgotEmail] = useState("");
+  const [forgotSent, setForgotSent] = useState(false);
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
   const navigate = useNavigate();
+
+  const handleForgotPassword = async () => {
+    setError("");
+    setLoading(true);
+    try {
+      await sendForgotPassword(forgotEmail);
+      setForgotSent(true);
+    } catch (err: unknown) {
+      const message = axios.isAxiosError(err)
+        ? (err.response?.data?.message ?? "Error al enviar el correo")
+        : "Error al enviar el correo";
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  };
 
   const handleLogin = async () => {
     setError("");
@@ -29,19 +50,16 @@ const Login: React.FC = () => {
     }
   };
 
-    return (
-        <div className="base-login">
-            <div className='logo-login'>
-                {forgotPassword && (
-                    <span
-                        className="volver"
-                        onClick={() => setForgotPassword(false)}
-                    >
-                        ← Volver al login
-                    </span>
-                )}
-                <img src={"/logo.png"} alt="goblin" className="goblin-login" />
-            </div>
+  return (
+    <div className="base-login">
+      <div className="logo-login">
+        {forgotPassword && (
+          <span className="volver" onClick={() => setForgotPassword(false)}>
+            ← Volver al login
+          </span>
+        )}
+        <img src={"/logo.png"} alt="goblin" className="goblin-login" />
+      </div>
 
       {!forgotPassword ? (
         // ——— VISTA LOGIN ———
@@ -73,20 +91,41 @@ const Login: React.FC = () => {
         // ——— VISTA RECUPERAR CONTRASEÑA ———
         <div className="form-login">
           <label className="inicio-sesion">Recuperar Contraseña</label>
-          <label className="instrucciones">
-            Ingresa tu correo electrónico y te enviaremos un código para
-            restablecer tu contraseña.
-          </label>
-          <input type="text" placeholder="Correo electrónico" />
-          <div className="botones">
-            <button className="entrar">Enviar Código</button>
-            <button
-              className="cancelar"
-              onClick={() => setForgotPassword(false)}
-            >
-              Cancelar
-            </button>
-          </div>
+          {forgotSent ? (
+            <label className="instrucciones">
+              Revisa tu correo, te enviamos un enlace para restablecer tu
+              contraseña.
+            </label>
+          ) : (
+            <>
+              <label className="instrucciones">
+                Ingresa tu correo electrónico y te enviaremos un código para
+                restablecer tu contraseña.
+              </label>
+              <input
+                type="text"
+                placeholder="Correo electrónico"
+                value={forgotEmail}
+                onChange={(e) => setForgotEmail(e.target.value)}
+              />
+              {error && <span className="error-msg">{error}</span>}
+              <div className="botones">
+                <button
+                  className="entrar"
+                  onClick={handleForgotPassword}
+                  disabled={loading}
+                >
+                  {loading ? "Enviando..." : "Enviar Código"}
+                </button>
+                <button
+                  className="cancelar"
+                  onClick={() => setForgotPassword(false)}
+                >
+                  Cancelar
+                </button>
+              </div>
+            </>
+          )}
         </div>
       )}
     </div>

--- a/goblinhub_web/src/pages/resetPassword/ResetPassword.tsx
+++ b/goblinhub_web/src/pages/resetPassword/ResetPassword.tsx
@@ -1,0 +1,107 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import axios from "axios";
+import api from "../../lib/api";
+
+const ResetPassword: React.FC = () => {
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+  const navigate = useNavigate();
+
+  // Supabase redirige con el token en el hash de la URL:
+  // /reset-password#access_token=TOKEN&type=recovery
+  const hash = new URLSearchParams(window.location.hash.substring(1));
+  const accessToken = hash.get("access_token");
+  const type = hash.get("type");
+
+  if (!accessToken || type !== "recovery") {
+    return <p>Enlace inválido o expirado. Solicita uno nuevo.</p>;
+  }
+
+  const handleSubmit = async () => {
+    setError("");
+
+    if (newPassword !== confirmPassword) {
+      setError("Las contraseñas no coinciden");
+      return;
+    }
+
+    if (newPassword.length < 8) {
+      setError("La contraseña debe tener al menos 8 caracteres");
+      return;
+    }
+
+    if (
+      !/[a-z]/.test(newPassword) ||
+      !/[A-Z]/.test(newPassword) ||
+      !/[0-9]/.test(newPassword)
+    ) {
+      setError(
+        "La contraseña debe tener al menos una minúscula, una mayúscula y un número",
+      );
+      return;
+    }
+
+    setLoading(true);
+    try {
+      await api.post("/auth/reset-password", {
+        accessToken,
+        newPassword,
+        confirmPassword,
+      });
+      navigate("/login");
+    } catch (err: unknown) {
+      const message = axios.isAxiosError(err)
+        ? (err.response?.data?.message ?? "Error al cambiar la contraseña")
+        : "Error al cambiar la contraseña";
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div>
+      <h2>Nueva contraseña</h2>
+
+      <input
+        type="password"
+        placeholder="Nueva contraseña"
+        value={newPassword}
+        onChange={(e) => setNewPassword(e.target.value)}
+      />
+
+      <input
+        type="password"
+        placeholder="Confirmar contraseña"
+        value={confirmPassword}
+        onChange={(e) => setConfirmPassword(e.target.value)}
+      />
+
+      <ul style={{ fontSize: "13px", marginTop: "8px", paddingLeft: "18px" }}>
+        <li style={{ color: newPassword.length >= 8 ? "green" : "gray" }}>
+          Mínimo 8 caracteres
+        </li>
+        <li style={{ color: /[a-z]/.test(newPassword) ? "green" : "gray" }}>
+          Al menos una minúscula
+        </li>
+        <li style={{ color: /[A-Z]/.test(newPassword) ? "green" : "gray" }}>
+          Al menos una mayúscula
+        </li>
+        <li style={{ color: /[0-9]/.test(newPassword) ? "green" : "gray" }}>
+          Al menos un número
+        </li>
+      </ul>
+
+      {error && <p style={{ color: "red" }}>{error}</p>}
+
+      <button onClick={handleSubmit} disabled={loading}>
+        {loading ? "Guardando..." : "Cambiar contraseña"}
+      </button>
+    </div>
+  );
+};
+
+export default ResetPassword;

--- a/goblinhub_web/src/services/auth.service.ts
+++ b/goblinhub_web/src/services/auth.service.ts
@@ -12,3 +12,17 @@ export const getMe = () => api.get<MeResponseDto>("/auth/me");
 export const logout = () => {
   localStorage.removeItem("token");
 };
+
+export const forgotPassword = (email: string) =>
+  api.post("/auth/forgot-password", { email });
+
+export const resetPassword = (
+  accessToken: string,
+  newPassword: string,
+  confirmPassword: string,
+) =>
+  api.post("/auth/reset-password", {
+    accessToken,
+    newPassword,
+    confirmPassword,
+  });


### PR DESCRIPTION
## 📌 Resumen del Cambio

Se implementa el flujo completo de **recuperación de contraseña olvidada** en el backend (NestJS) y el frontend (React). El usuario puede solicitar un enlace de recuperación por email y establecer una nueva contraseña desde la UI. Adicionalmente, se renombran los métodos `execute()` en varios use cases de eventos, recompensas y autenticación para hacerlos más descriptivos y mantenibles.

---

## 🔍 Tipo de Cambio realizado

Marca con una `x` lo que aplica:

- [ ] 🐞 Corrección de error (`fix`)
- [x] ✨ Nueva funcionalidad (`feat`)
- [x] ♻️ Refactorización del código sin cambios funcionales (`refactor`)
- [ ] 🧪 Agregado o mejora de pruebas (`test`)
- [ ] 🧱 Cambio en configuración CI/CD (`ci`)
- [ ] 🚀 Mejora de rendimiento (`perf`)
- [ ] 📚 Cambios en la documentación (`docs`)
- [ ] Otro (especificar):

---

## 📂 Archivos Afectados

**Backend (`goblinhub-api`):**

- `src/modules/supabase/application/use-case/forgot-password.use-case.ts` — nuevo use case: envía email de recuperación vía Supabase
- `src/modules/supabase/application/use-case/reset-password.use-case.ts` — nuevo use case: valida token y actualiza contraseña
- `src/modules/supabase/application/dto/auth.dto.ts` — nuevos DTOs: `ForgotPasswordDto`, `ResetPasswordDto`
- `src/modules/supabase/infrastructure/controller/supabase-auth.controller.ts` — nuevos endpoints `POST /auth/forgot-password` y `POST /auth/reset-password`
- `src/modules/supabase/supabase.module.ts` — registro de los nuevos use cases
- `src/modules/events/application/use-case/expire-and-soft-delete-events.use-case.ts` — `execute()` → `expireAndSoftDeleteEvents()`
- `src/modules/rewards/aplication/use-case/create-reward.use-case.ts` — `execute()` → `createReward()`
- Varios use cases de auth — `execute()` renombrados a nombres descriptivos

**Frontend (`goblinhub_web`):**

- `src/pages/resetPassword/ResetPassword.tsx` — nueva página de reseteo de contraseña
- `src/features/landing/components/` — componente del flujo de forgot password
- `src/App.tsx` — nuevas rutas para las páginas de recuperación

---

## 🧪 ¿Cómo Probarlo?

**Forgot password (backend):**

1. `POST /auth/forgot-password` con `{ "email": "usuario@ejemplo.com" }`
2. Verificar que llega el email con el enlace de recuperación (redirige a `SUPABASE_RESET_PASSWORD_URL`)
3. Con email inexistente: debe devolver el mismo mensaje sin revelar si existe o no

**Reset password (backend):**

1. Usar el `access_token` del enlace recibido por email
2. `POST /auth/reset-password` con `{ "accessToken": "...", "newPassword": "Nueva123", "confirmPassword": "Nueva123" }`
3. Verificar respuesta `200 OK` y que la nueva contraseña funciona en `POST /auth/signin`
4. Contraseñas que no coinciden deben devolver `400 Bad Request`

**Frontend:**

1. En la pantalla de login, hacer clic en "¿Olvidaste tu contraseña?"
2. Ingresar email y verificar que aparece confirmación de envío
3. Abrir el enlace del email → debe abrir la página `/reset-password`
4. Ingresar nueva contraseña y confirmar → redirige al login con mensaje de éxito

---

## ✅ Checklist

Asegúrate de completar lo siguiente antes de enviar:

- [x] He probado mis cambios localmente
- [x] Esta PR sigue el formato de convención de commits (si aplica)
- [ ] Se han actualizado o agregado pruebas
- [ ] La documentación se actualizó si fue necesario
- [x] No hay errores en CI/CD

---

## 📎 Notas Adicionales

- Resuelve el issue #92
- La variable de entorno `SUPABASE_RESET_PASSWORD_URL` debe estar configurada en el servidor apuntando a la URL del frontend (ej. `https://tudominio.com/reset-password`)
- El `access_token` del enlace de recuperación tiene una validez limitada definida por Supabase (por defecto 1 hora)

---

Gracias 🙌