### PR TITLE
96 fix resolver vulnerabilidades críticas de seguridad en el backend

### DIFF
--- a/goblinhub-api/package-lock.json
+++ b/goblinhub-api/package-lock.json
@@ -17,6 +17,7 @@
         "@nestjs/platform-express": "^11.0.1",
         "@nestjs/schedule": "^6.1.1",
         "@nestjs/swagger": "^11.2.6",
+        "@nestjs/throttler": "^6.5.0",
         "@prisma/adapter-pg": "^7.4.1",
         "@prisma/client": "^7.4.1",
         "@supabase/supabase-js": "^2.97.0",
@@ -2736,6 +2737,17 @@
         "@nestjs/platform-express": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@nestjs/throttler": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/throttler/-/throttler-6.5.0.tgz",
+      "integrity": "sha512-9j0ZRfH0QE1qyrj9JjIRDz5gQLPqq9yVC2nHsrosDVAfI5HHw08/aUAWx9DZLSdQf4HDkmhTTEGLrRFHENvchQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
+        "reflect-metadata": "^0.1.13 || ^0.2.0"
       }
     },
     "node_modules/@noble/hashes": {

--- a/goblinhub-api/package.json
+++ b/goblinhub-api/package.json
@@ -28,6 +28,7 @@
     "@nestjs/platform-express": "^11.0.1",
     "@nestjs/schedule": "^6.1.1",
     "@nestjs/swagger": "^11.2.6",
+    "@nestjs/throttler": "^6.5.0",
     "@prisma/adapter-pg": "^7.4.1",
     "@prisma/client": "^7.4.1",
     "@supabase/supabase-js": "^2.97.0",

--- a/goblinhub-api/prisma/migrations/20260306052040_add_id_creador_to_producto_and_recompensa/migration.sql
+++ b/goblinhub-api/prisma/migrations/20260306052040_add_id_creador_to_producto_and_recompensa/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "productos" ADD COLUMN     "id_creador" UUID;
+
+-- AlterTable
+ALTER TABLE "recompensas" ADD COLUMN     "id_creador" UUID;

--- a/goblinhub-api/prisma/schema.prisma
+++ b/goblinhub-api/prisma/schema.prisma
@@ -229,6 +229,7 @@ model Producto {
   es_nuevo        Boolean           @default(false)
   imagen_url      String?           @db.VarChar(500)
   activo          Boolean           @default(true)
+  id_creador      String?           @db.Uuid
   
   created_at      DateTime          @default(now())
   updated_at      DateTime          @updatedAt
@@ -285,6 +286,7 @@ model Recompensa {
   tipo            TipoRecompensa
   valor_descuento Decimal?       @db.Decimal(5, 2)
   activa          Boolean        @default(true)
+  id_creador      String?        @db.Uuid
   
   created_at      DateTime       @default(now())
   updated_at      DateTime       @updatedAt

--- a/goblinhub-api/src/app.module.ts
+++ b/goblinhub-api/src/app.module.ts
@@ -6,9 +6,17 @@ import { SupabaseAuthModule } from './modules/supabase/supabase-auth.module';
 import { BackupModule } from './modules/backup/backup.module';
 import { RewardModule } from './modules/rewards/reward.module';
 import { ProductoModule } from './modules/products/product.module';
+import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
+import { APP_GUARD } from '@nestjs/core';
 
 @Module({
   imports: [
+    ThrottlerModule.forRoot([
+      {
+        ttl: 60000,
+        limit: 10,
+      },
+    ]), // Limita a 10 solicitudes por minuto
     ConfigModule.forRoot({
       isGlobal: true,
     }),
@@ -20,6 +28,11 @@ import { ProductoModule } from './modules/products/product.module';
     ProductoModule,
   ],
   controllers: [],
-  providers: [],
+  providers: [
+    {
+      provide: APP_GUARD,
+      useClass: ThrottlerGuard,
+    },
+  ], // Aplica el guard de throttling globalmente
 })
 export class AppModule {}

--- a/goblinhub-api/src/modules/events/application/use-case/sd-event.use-case.spec.ts
+++ b/goblinhub-api/src/modules/events/application/use-case/sd-event.use-case.spec.ts
@@ -54,26 +54,34 @@ describe('SoftDeleteEventUseCase', () => {
     ).rejects.toThrow(HttpException);
   });
 
-  it('debe lanzar ForbiddenException si no es admin ni el creador', async () => {
-    eventRepo.findById.mockResolvedValue(mockEvent); // Creador es 'creador-123'
-    userRepo.findRolById.mockResolvedValue(null); // No es admin
+  it('debe lanzar ForbiddenException si no es admin ni empleado', async () => {
+    eventRepo.findById.mockResolvedValue(mockEvent);
+    userRepo.findRolById.mockResolvedValue(RolUsuario.jugador);
 
-    // Intentamos borrar con un usuario que NO es el creador ('user-intruso')
     await expect(
       useCase.softDeleteEvent('evento-123', 'user-intruso'),
     ).rejects.toThrow(ForbiddenException);
   });
 
-  it('debe permitir borrar si el usuario es el creador (aunque no sea admin)', async () => {
-    eventRepo.findById.mockResolvedValue(mockEvent); // Creador es 'creador-123'
-    userRepo.findRolById.mockResolvedValue(null); // No es admin
+  it('debe permitir borrar si el usuario es el creador (empleado)', async () => {
+    eventRepo.findById.mockResolvedValue(mockEvent);
+    userRepo.findRolById.mockResolvedValue(RolUsuario.empleado);
     eventRepo.delete.mockResolvedValue(mockEvent);
 
-    const result = await useCase.softDeleteEvent('evento-123', 'creador-123'); // Mismo ID que el creador
+    const result = await useCase.softDeleteEvent('evento-123', 'creador-123');
 
     // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(eventRepo.delete).toHaveBeenCalledWith('evento-123');
     expect(result).toEqual(mockEvent);
+  });
+
+  it('debe lanzar ForbiddenException si empleado intenta borrar evento de otro', async () => {
+    eventRepo.findById.mockResolvedValue(mockEvent); // Creador es 'creador-123'
+    userRepo.findRolById.mockResolvedValue(RolUsuario.empleado);
+
+    await expect(
+      useCase.softDeleteEvent('evento-123', 'otro-empleado'),
+    ).rejects.toThrow(ForbiddenException);
   });
 
   it('debe permitir borrar si el usuario es Admin (aunque no sea el creador)', async () => {

--- a/goblinhub-api/src/modules/events/application/use-case/sd-event.use-case.ts
+++ b/goblinhub-api/src/modules/events/application/use-case/sd-event.use-case.ts
@@ -25,11 +25,10 @@ export class SoftDeleteEventUseCase {
       }
 
       const rol = await this.usuarios.findRolById(id_usuario);
-      const isAdmin = rol === RolUsuario.admin;
 
-      if (!isAdmin && event.id_creador && event.id_creador !== id_usuario) {
+      if (rol !== RolUsuario.admin) {
         throw new ForbiddenException(
-          'You do not have permission to delete this event',
+          'Solo un administrador puede eliminar eventos',
         );
       }
 

--- a/goblinhub-api/src/modules/events/application/use-case/sd-event.use-case.ts
+++ b/goblinhub-api/src/modules/events/application/use-case/sd-event.use-case.ts
@@ -25,10 +25,18 @@ export class SoftDeleteEventUseCase {
       }
 
       const rol = await this.usuarios.findRolById(id_usuario);
+      const isAdmin = rol === RolUsuario.admin;
+      const isEmpleado = rol === RolUsuario.empleado;
 
-      if (rol !== RolUsuario.admin) {
+      if (!isAdmin && !isEmpleado) {
         throw new ForbiddenException(
-          'Solo un administrador puede eliminar eventos',
+          'You do not have permission to delete events.',
+        );
+      }
+
+      if (isEmpleado && event.id_creador && event.id_creador !== id_usuario) {
+        throw new ForbiddenException(
+          'You can only delete events that you created.',
         );
       }
 

--- a/goblinhub-api/src/modules/events/application/use-case/update-event.use-case.spec.ts
+++ b/goblinhub-api/src/modules/events/application/use-case/update-event.use-case.spec.ts
@@ -52,9 +52,9 @@ describe('UpdateEventUseCase', () => {
     ).rejects.toThrow(HttpException);
   });
 
-  it('debe lanzar ForbiddenException si no es admin ni el creador', async () => {
+  it('debe lanzar ForbiddenException si no es admin ni empleado', async () => {
     eventRepo.findById.mockResolvedValue(mockEvent);
-    userRepo.findRolById.mockResolvedValue(null);
+    userRepo.findRolById.mockResolvedValue(RolUsuario.jugador);
 
     await expect(
       useCase.updateEvent('id-123', {} as UpdateEventDto, 'intruso-456'),
@@ -89,7 +89,7 @@ describe('UpdateEventUseCase', () => {
     ).rejects.toThrow(HttpException);
   });
 
-  it('debe actualizar correctamente si el usuario es el Creador', async () => {
+  it('debe actualizar correctamente si el usuario es el Creador (empleado)', async () => {
     const updatedEvent = new Event(
       'id-123',
       'Editado',
@@ -110,7 +110,7 @@ describe('UpdateEventUseCase', () => {
     );
 
     eventRepo.findById.mockResolvedValue(mockEvent);
-    userRepo.findRolById.mockResolvedValue(null);
+    userRepo.findRolById.mockResolvedValue(RolUsuario.empleado);
     eventRepo.findByName.mockResolvedValue(null);
     eventRepo.update.mockResolvedValue(updatedEvent);
 
@@ -123,6 +123,19 @@ describe('UpdateEventUseCase', () => {
     // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(eventRepo.update).toHaveBeenCalled();
     expect(result.titulo).toBe('Editado');
+  });
+
+  it('debe lanzar ForbiddenException si empleado intenta actualizar evento de otro', async () => {
+    eventRepo.findById.mockResolvedValue(mockEvent); // Creador es 'creador-123'
+    userRepo.findRolById.mockResolvedValue(RolUsuario.empleado);
+
+    await expect(
+      useCase.updateEvent(
+        'id-123',
+        { titulo: 'Hack' } as UpdateEventDto,
+        'otro-empleado',
+      ),
+    ).rejects.toThrow(ForbiddenException);
   });
 
   it('debe actualizar correctamente si el usuario es Admin', async () => {

--- a/goblinhub-api/src/modules/events/application/use-case/update-event.use-case.ts
+++ b/goblinhub-api/src/modules/events/application/use-case/update-event.use-case.ts
@@ -29,15 +29,16 @@ export class UpdateEventUseCase {
 
       const rol = await this.usuarios.findRolById(id_usuario);
       const isAdmin = rol === RolUsuario.admin;
+      const isEmpleado = rol === RolUsuario.empleado;
 
-      if (!isAdmin && rol !== RolUsuario.empleado) {
+      if (!isAdmin && !isEmpleado) {
         throw new ForbiddenException(
           'You do not have permission to update events',
         );
       }
 
       if (
-        !isAdmin &&
+        isEmpleado &&
         existEvent.id_creador &&
         existEvent.id_creador !== id_usuario
       ) {

--- a/goblinhub-api/src/modules/events/application/use-case/update-event.use-case.ts
+++ b/goblinhub-api/src/modules/events/application/use-case/update-event.use-case.ts
@@ -30,6 +30,12 @@ export class UpdateEventUseCase {
       const rol = await this.usuarios.findRolById(id_usuario);
       const isAdmin = rol === RolUsuario.admin;
 
+      if (!isAdmin && rol !== RolUsuario.empleado) {
+        throw new ForbiddenException(
+          'You do not have permission to update events',
+        );
+      }
+
       if (
         !isAdmin &&
         existEvent.id_creador &&

--- a/goblinhub-api/src/modules/events/interfaces/controllers/event.controller.ts
+++ b/goblinhub-api/src/modules/events/interfaces/controllers/event.controller.ts
@@ -27,6 +27,9 @@ import { Event } from '../../domain/entities/event.entity';
 import { CreateEventDto } from '../../application/dtos/create-event.dto';
 import { UpdateEventDto } from '../../application/dtos/update-event.dto';
 import { SupabaseAuthGuard } from '../../../supabase/guard/supabse-auth.guard';
+import { RolesGuard } from '../../../supabase/guard/roles.guard';
+import { Roles } from '../../../supabase/guard/roles.decorator';
+import { RolUsuario } from '../../../supabase/domain/enums/user.enum';
 import type { AuthenticatedRequest } from '../../../supabase/interfaces/types/authenticated-request.interface';
 
 @ApiTags('events') // Requerido por el issue
@@ -67,7 +70,8 @@ export class EventController {
   }
 
   @Post()
-  @UseGuards(SupabaseAuthGuard)
+  @UseGuards(SupabaseAuthGuard, RolesGuard)
+  @Roles(RolUsuario.admin, RolUsuario.empleado)
   @ApiBearerAuth('access-token') // Candado requerido por el issue
   @ApiOperation({ summary: 'Crear un nuevo evento (Privado)' })
   @ApiResponse({
@@ -87,7 +91,8 @@ export class EventController {
   }
 
   @Put(':id')
-  @UseGuards(SupabaseAuthGuard)
+  @UseGuards(SupabaseAuthGuard, RolesGuard)
+  @Roles(RolUsuario.admin, RolUsuario.empleado)
   @ApiBearerAuth('access-token')
   @ApiOperation({ summary: 'Actualizar un evento existente' })
   @ApiParam({ name: 'id', description: 'UUID del evento a modificar' })
@@ -110,7 +115,8 @@ export class EventController {
   }
 
   @Delete(':id')
-  @UseGuards(SupabaseAuthGuard)
+  @UseGuards(SupabaseAuthGuard, RolesGuard)
+  @Roles(RolUsuario.admin)
   @ApiBearerAuth('access-token')
   @ApiOperation({ summary: 'Eliminar un evento (Soft Delete)' })
   @ApiParam({ name: 'id', description: 'UUID del evento a eliminar' })

--- a/goblinhub-api/src/modules/products/aplication/use-case/create-product.use-case.ts
+++ b/goblinhub-api/src/modules/products/aplication/use-case/create-product.use-case.ts
@@ -44,7 +44,7 @@ export class CreateProductoUseCase {
       );
 
       // 3. Guardamos en la base de datos
-      return await this.productoRepository.create(newProducto);
+      return await this.productoRepository.create(newProducto, id_creador);
     } catch (error) {
       if (
         error instanceof HttpException ||

--- a/goblinhub-api/src/modules/products/aplication/use-case/soft-deled-product.use-case.ts
+++ b/goblinhub-api/src/modules/products/aplication/use-case/soft-deled-product.use-case.ts
@@ -12,12 +12,12 @@ export class SoftDeleteProductoUseCase {
 
   async softDeleteProducto(id: string, id_usuario: string): Promise<void> {
     try {
-      // 1. Validar permisos del usuario
+      // 1. Validar que solo admin puede eliminar
       const rol = await this.usuarioRepository.findRolById(id_usuario);
 
-      if (rol !== RolUsuario.admin && rol !== RolUsuario.empleado) {
+      if (rol !== RolUsuario.admin) {
         throw new ForbiddenException(
-          'No tienes permisos para eliminar productos',
+          'Solo un administrador puede eliminar productos',
         );
       }
 

--- a/goblinhub-api/src/modules/products/aplication/use-case/update-product.use-case.ts
+++ b/goblinhub-api/src/modules/products/aplication/use-case/update-product.use-case.ts
@@ -20,8 +20,9 @@ export class UpdateProductoUseCase {
     try {
       // 1. Validar permisos del usuario
       const rol = await this.usuarioRepository.findRolById(id_usuario);
+      const isAdmin = rol === RolUsuario.admin;
 
-      if (rol !== RolUsuario.admin && rol !== RolUsuario.empleado) {
+      if (!isAdmin && rol !== RolUsuario.empleado) {
         throw new ForbiddenException(
           'No tienes permisos para actualizar productos',
         );
@@ -34,8 +35,13 @@ export class UpdateProductoUseCase {
         throw new HttpException({ Error: 'No se encontró el producto' }, 404);
       }
 
-      // 2. Construimos la entidad actualizada usando Nullish Coalescing (??)
-      // Si "data" trae el campo, lo usamos; si no, conservamos el de "existProducto"
+      // 3. Verificar propiedad si es empleado
+      if (!isAdmin && existProducto.id_creador !== id_usuario) {
+        throw new ForbiddenException(
+          'Solo puedes editar productos que hayas creado tú',
+        );
+      }
+
       const updatedProducto = new Producto(
         // --- Requeridos ---
         existProducto.id_producto,

--- a/goblinhub-api/src/modules/products/domain/entities/product.entity.ts
+++ b/goblinhub-api/src/modules/products/domain/entities/product.entity.ts
@@ -21,5 +21,6 @@ export class Producto {
     public precio_original?: number,
     public imagen_url?: string,
     public deleted_at?: Date,
+    public id_creador?: string,
   ) {}
 }

--- a/goblinhub-api/src/modules/products/domain/repositories/product.respository.ts
+++ b/goblinhub-api/src/modules/products/domain/repositories/product.respository.ts
@@ -1,7 +1,7 @@
 import { Producto } from '../entities/product.entity';
 
 export abstract class ProductRepository {
-  abstract create(product: Producto): Promise<Producto>;
+  abstract create(product: Producto, id_creador: string): Promise<Producto>;
   abstract findById(id: string): Promise<Producto | null>;
   abstract findAll(): Promise<Producto[]>;
   abstract findByCategory(category: string): Promise<Producto[]>;

--- a/goblinhub-api/src/modules/products/infrastructure/prisma/product.repository.ts
+++ b/goblinhub-api/src/modules/products/infrastructure/prisma/product.repository.ts
@@ -35,7 +35,7 @@ export class ProductoPrismaRepository extends ProductRepository {
         : undefined,
       prismaProducto.imagen_url ?? undefined,
       prismaProducto.deleted_at ?? undefined,
-      prismaProducto.id_creador ?? undefined,
+      (prismaProducto.id_creador as string | null | undefined) ?? undefined,
     );
   }
 

--- a/goblinhub-api/src/modules/products/infrastructure/prisma/product.repository.ts
+++ b/goblinhub-api/src/modules/products/infrastructure/prisma/product.repository.ts
@@ -35,10 +35,11 @@ export class ProductoPrismaRepository extends ProductRepository {
         : undefined,
       prismaProducto.imagen_url ?? undefined,
       prismaProducto.deleted_at ?? undefined,
+      prismaProducto.id_creador ?? undefined,
     );
   }
 
-  async create(producto: Producto): Promise<Producto> {
+  async create(producto: Producto, id_creador: string): Promise<Producto> {
     const created = await this.prisma.producto.create({
       data: {
         nombre: producto.nombre,
@@ -53,6 +54,7 @@ export class ProductoPrismaRepository extends ProductRepository {
         es_nuevo: producto.es_nuevo,
         imagen_url: producto.imagen_url,
         activo: producto.activo,
+        id_creador: id_creador,
       },
     });
 

--- a/goblinhub-api/src/modules/products/interfaces/controllers/product.controller.ts
+++ b/goblinhub-api/src/modules/products/interfaces/controllers/product.controller.ts
@@ -18,15 +18,18 @@ import {
   ApiBearerAuth,
 } from '@nestjs/swagger'; // Importaciones de Swagger
 import { SupabaseAuthGuard } from '../../../supabase/guard/supabse-auth.guard';
+import { RolesGuard } from '../../../supabase/guard/roles.guard';
+import { Roles } from '../../../supabase/guard/roles.decorator';
+import { RolUsuario } from '../../../supabase/domain/enums/user.enum';
+import { CategoriaProducto } from '../../domain/enums/product.enum';
+import type { AuthenticatedRequest } from '../../../supabase/interfaces/types/authenticated-request.interface';
+import { GetProductoUseCase } from '../../aplication/use-case/get-product.use-case';
 import { CreateProductoUseCase } from '../../aplication/use-case/create-product.use-case';
 import { UpdateProductoUseCase } from '../../aplication/use-case/update-product.use-case';
 import { SoftDeleteProductoUseCase } from '../../aplication/use-case/soft-deled-product.use-case';
-import { GetProductoUseCase } from '../../aplication/use-case/get-product.use-case';
 import { Producto } from '../../domain/entities/product.entity';
 import { CreateProductoDto } from '../../aplication/dtos/create-product.dtos';
 import { UpdateProductoDto } from '../../aplication/dtos/update-product.dto';
-import { CategoriaProducto } from '../../domain/enums/product.enum';
-import type { AuthenticatedRequest } from '../../../supabase/interfaces/types/authenticated-request.interface';
 
 @ApiTags('Productos') // Agrupa este controlador en la sección "Productos" de Swagger
 @Controller('productos')
@@ -79,7 +82,8 @@ export class ProductoController {
   }
 
   @Post()
-  @UseGuards(SupabaseAuthGuard)
+  @UseGuards(SupabaseAuthGuard, RolesGuard)
+  @Roles(RolUsuario.admin, RolUsuario.empleado)
   @ApiBearerAuth('access-token') // Requiere token JWT
   @ApiOperation({ summary: 'Crear un nuevo producto (Admin)' })
   @ApiResponse({ status: 201, description: 'Producto creado exitosamente.' })
@@ -96,7 +100,8 @@ export class ProductoController {
   }
 
   @Put(':id')
-  @UseGuards(SupabaseAuthGuard)
+  @UseGuards(SupabaseAuthGuard, RolesGuard)
+  @Roles(RolUsuario.admin, RolUsuario.empleado)
   @ApiBearerAuth('access-token')
   @ApiParam({ name: 'id', description: 'UUID del producto a actualizar' })
   @ApiResponse({ status: 200, description: 'Producto actualizado.' })
@@ -118,7 +123,8 @@ export class ProductoController {
   }
 
   @Delete(':id')
-  @UseGuards(SupabaseAuthGuard)
+  @UseGuards(SupabaseAuthGuard, RolesGuard)
+  @Roles(RolUsuario.admin)
   @ApiBearerAuth('access-token')
   @ApiOperation({ summary: 'Eliminación lógica de un producto' })
   @ApiParam({ name: 'id', description: 'UUID del producto a eliminar' })

--- a/goblinhub-api/src/modules/rewards/aplication/use-case/create-reward.use-case.ts
+++ b/goblinhub-api/src/modules/rewards/aplication/use-case/create-reward.use-case.ts
@@ -66,7 +66,7 @@ export class CreateRewardUseCase {
       );
 
       // 5. Guardar en base de datos
-      return this.rewardRepository.create(reward);
+      return this.rewardRepository.create(reward, id_creador);
     } catch (error) {
       if (
         error instanceof HttpException ||

--- a/goblinhub-api/src/modules/rewards/aplication/use-case/sd-reward.use-case.ts
+++ b/goblinhub-api/src/modules/rewards/aplication/use-case/sd-reward.use-case.ts
@@ -1,12 +1,26 @@
-import { HttpException, Injectable } from '@nestjs/common';
+import { ForbiddenException, HttpException, Injectable } from '@nestjs/common';
 import { RewardRepository } from '../../domain/repositories/reward.repository';
+import { UsuarioRepository } from '../../../supabase/domain/repositories/usuario.repository';
+import { RolUsuario } from '../../../supabase/domain/enums/user.enum';
 
 @Injectable()
 export class SoftDeleteRewardUseCase {
-  constructor(private rewardRepository: RewardRepository) {}
+  constructor(
+    private rewardRepository: RewardRepository,
+    private usuarioRepository: UsuarioRepository,
+  ) {}
 
-  async softDeleteReward(id: number): Promise<void> {
+  async softDeleteReward(id: number, id_usuario: string): Promise<void> {
     try {
+      // 1. Validar que solo admin puede eliminar
+      const rol = await this.usuarioRepository.findRolById(id_usuario);
+
+      if (rol !== RolUsuario.admin) {
+        throw new ForbiddenException(
+          'Solo un administrador puede eliminar recompensas',
+        );
+      }
+
       const rewardExistente = await this.rewardRepository.findById(id);
 
       if (!rewardExistente) {
@@ -18,7 +32,10 @@ export class SoftDeleteRewardUseCase {
 
       await this.rewardRepository.delete(id);
     } catch (error) {
-      if (error instanceof HttpException) {
+      if (
+        error instanceof HttpException ||
+        error instanceof ForbiddenException
+      ) {
         throw error;
       }
       throw new HttpException(

--- a/goblinhub-api/src/modules/rewards/aplication/use-case/soft-delete-reward.use-case.spec.ts
+++ b/goblinhub-api/src/modules/rewards/aplication/use-case/soft-delete-reward.use-case.spec.ts
@@ -1,14 +1,18 @@
 import { SoftDeleteRewardUseCase } from './sd-reward.use-case';
 import { RewardRepository } from '../../domain/repositories/reward.repository';
+import { UsuarioRepository } from '../../../supabase/domain/repositories/usuario.repository';
 import { HttpException } from '@nestjs/common';
 import { Recompensa } from '../../domain/entities/reward.entity';
 import { TipoRecompensa } from '../../domain/enums/reward.enum';
+import { RolUsuario } from '../../../supabase/domain/enums/user.enum';
 
 describe('SoftDeleteRewardUseCase', () => {
   let useCase: SoftDeleteRewardUseCase;
   let rewardRepo: jest.Mocked<RewardRepository>;
+  let usuarioRepo: jest.Mocked<UsuarioRepository>;
 
   const mockId = 1;
+  const adminUserId = 'admin-uuid-1234';
 
   beforeEach(() => {
     rewardRepo = {
@@ -16,7 +20,11 @@ describe('SoftDeleteRewardUseCase', () => {
       delete: jest.fn(),
     } as unknown as jest.Mocked<RewardRepository>;
 
-    useCase = new SoftDeleteRewardUseCase(rewardRepo);
+    usuarioRepo = {
+      findRolById: jest.fn().mockResolvedValue(RolUsuario.admin),
+    } as unknown as jest.Mocked<UsuarioRepository>;
+
+    useCase = new SoftDeleteRewardUseCase(rewardRepo, usuarioRepo);
   });
 
   it('debe realizar el soft delete exitosamente si la recompensa existe', async () => {
@@ -27,7 +35,7 @@ describe('SoftDeleteRewardUseCase', () => {
     // 2. Simulamos que el delete funciona (retorna void)
     rewardRepo.delete.mockResolvedValue(undefined);
 
-    await useCase.softDeleteReward(mockId);
+    await useCase.softDeleteReward(mockId, adminUserId);
 
     // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(rewardRepo.findById).toHaveBeenCalledWith(mockId);
@@ -39,7 +47,7 @@ describe('SoftDeleteRewardUseCase', () => {
     // Simulamos que el repositorio devuelve null
     rewardRepo.findById.mockResolvedValue(null);
 
-    await expect(useCase.softDeleteReward(mockId)).rejects.toThrow(
+    await expect(useCase.softDeleteReward(mockId, adminUserId)).rejects.toThrow(
       HttpException,
     );
 
@@ -52,7 +60,7 @@ describe('SoftDeleteRewardUseCase', () => {
     // Simulamos un error genérico (ej. base de datos fuera de línea)
     rewardRepo.findById.mockRejectedValue(new Error('Fallo de conexión'));
 
-    await expect(useCase.softDeleteReward(mockId)).rejects.toThrow(
+    await expect(useCase.softDeleteReward(mockId, adminUserId)).rejects.toThrow(
       HttpException,
     );
   });
@@ -62,6 +70,8 @@ describe('SoftDeleteRewardUseCase', () => {
     const customError = new HttpException('Error manual', 403);
     rewardRepo.findById.mockRejectedValue(customError);
 
-    await expect(useCase.softDeleteReward(mockId)).rejects.toThrow(customError);
+    await expect(useCase.softDeleteReward(mockId, adminUserId)).rejects.toThrow(
+      customError,
+    );
   });
 });

--- a/goblinhub-api/src/modules/rewards/aplication/use-case/update-reward.use-case.spec.ts
+++ b/goblinhub-api/src/modules/rewards/aplication/use-case/update-reward.use-case.spec.ts
@@ -1,13 +1,18 @@
 import { UpdateRewardUseCase } from './update-reward.use-case';
 import { RewardRepository } from '../../domain/repositories/reward.repository';
+import { UsuarioRepository } from '../../../supabase/domain/repositories/usuario.repository';
 import { HttpException } from '@nestjs/common';
 import { Recompensa } from '../../domain/entities/reward.entity';
 import { TipoRecompensa } from '../../domain/enums/reward.enum';
 import { UpdateRecompensaDto } from '../dtos/update-reward.dto';
+import { RolUsuario } from '../../../supabase/domain/enums/user.enum';
 
 describe('UpdateRewardUseCase', () => {
   let useCase: UpdateRewardUseCase;
   let rewardRepo: jest.Mocked<RewardRepository>;
+  let usuarioRepo: jest.Mocked<UsuarioRepository>;
+
+  const adminUserId = 'admin-uuid-1234';
 
   const mockExistingReward = new Recompensa(
     1,
@@ -25,7 +30,11 @@ describe('UpdateRewardUseCase', () => {
       update: jest.fn(),
     } as unknown as jest.Mocked<RewardRepository>;
 
-    useCase = new UpdateRewardUseCase(rewardRepo);
+    usuarioRepo = {
+      findRolById: jest.fn().mockResolvedValue(RolUsuario.admin),
+    } as unknown as jest.Mocked<UsuarioRepository>;
+
+    useCase = new UpdateRewardUseCase(rewardRepo, usuarioRepo);
   });
 
   it('debe actualizar la recompensa mezclando los nuevos datos con los existentes', async () => {
@@ -47,7 +56,7 @@ describe('UpdateRewardUseCase', () => {
     );
     rewardRepo.update.mockResolvedValue(updatedReward);
 
-    const result = await useCase.updateReward(1, updateDto);
+    const result = await useCase.updateReward(1, updateDto, adminUserId);
 
     // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(rewardRepo.update).toHaveBeenCalled();
@@ -62,7 +71,7 @@ describe('UpdateRewardUseCase', () => {
     rewardRepo.findById.mockResolvedValue(mockExistingReward);
     rewardRepo.update.mockResolvedValue(mockExistingReward);
 
-    const result = await useCase.updateReward(1, {}); // DTO vacío
+    const result = await useCase.updateReward(1, {}, adminUserId); // DTO vacío
 
     // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(rewardRepo.update).toHaveBeenCalled();
@@ -76,19 +85,25 @@ describe('UpdateRewardUseCase', () => {
   it('debe lanzar HttpException 404 si la recompensa no existe', async () => {
     rewardRepo.findById.mockResolvedValue(null);
 
-    await expect(useCase.updateReward(999, {})).rejects.toThrow(HttpException);
+    await expect(useCase.updateReward(999, {}, adminUserId)).rejects.toThrow(
+      HttpException,
+    );
   });
 
   it('debe lanzar HttpException 500 si el repositorio falla al buscar', async () => {
     rewardRepo.findById.mockRejectedValue(new Error('Error de base de datos'));
 
-    await expect(useCase.updateReward(1, {})).rejects.toThrow(HttpException);
+    await expect(useCase.updateReward(1, {}, adminUserId)).rejects.toThrow(
+      HttpException,
+    );
   });
 
   it('debe re-lanzar HttpException si ocurre dentro del catch', async () => {
     const errorHttp = new HttpException('No autorizado', 401);
     rewardRepo.findById.mockRejectedValue(errorHttp);
 
-    await expect(useCase.updateReward(1, {})).rejects.toThrow(errorHttp);
+    await expect(useCase.updateReward(1, {}, adminUserId)).rejects.toThrow(
+      errorHttp,
+    );
   });
 });

--- a/goblinhub-api/src/modules/rewards/aplication/use-case/update-reward.use-case.ts
+++ b/goblinhub-api/src/modules/rewards/aplication/use-case/update-reward.use-case.ts
@@ -1,26 +1,48 @@
-import { HttpException, Injectable } from '@nestjs/common';
+import { ForbiddenException, HttpException, Injectable } from '@nestjs/common';
 import { UpdateRecompensaDto } from '../dtos/update-reward.dto';
 import { Recompensa } from '../../domain/entities/reward.entity';
 import { RewardRepository } from '../../domain/repositories/reward.repository';
+import { UsuarioRepository } from '../../../supabase/domain/repositories/usuario.repository';
+import { RolUsuario } from '../../../supabase/domain/enums/user.enum';
 
 @Injectable()
 export class UpdateRewardUseCase {
-  constructor(private rewardRepository: RewardRepository) {}
+  constructor(
+    private rewardRepository: RewardRepository,
+    private usuarioRepository: UsuarioRepository,
+  ) {}
 
   async updateReward(
     id: number,
     data: UpdateRecompensaDto,
+    id_usuario: string,
   ): Promise<Recompensa> {
     try {
-      // 1. Verificamos que la recompensa exista por su ID
+      // 1. Validar rol
+      const rol = await this.usuarioRepository.findRolById(id_usuario);
+      const isAdmin = rol === RolUsuario.admin;
+
+      if (!isAdmin && rol !== RolUsuario.empleado) {
+        throw new ForbiddenException(
+          'No tienes permisos para actualizar recompensas',
+        );
+      }
+
+      // 2. Verificamos que la recompensa exista por su ID
       const existReward = await this.rewardRepository.findById(id);
 
       if (!existReward) {
         throw new HttpException({ Error: 'No se encontró la recompensa' }, 404);
       }
 
-      // 2. Construimos la entidad actualizada usando Nullish Coalescing (??)
-      // Si "data" trae el campo, lo usamos; si no, conservamos el de "existReward"
+      // 3. Verificar propiedad si es empleado
+      if (!isAdmin && existReward.id_creador !== id_usuario) {
+        throw new ForbiddenException(
+          'Solo puedes editar recompensas que hayas creado tú',
+        );
+      }
+
+      // 4. Construimos la entidad actualizada usando Nullish Coalescing (??)
       const updatedReward = new Recompensa(
         existReward.id,
         data.nombre ?? existReward.nombre,
@@ -31,10 +53,13 @@ export class UpdateRewardUseCase {
         data.activa ?? existReward.activa,
       );
 
-      // 3. Guardamos los cambios
+      // 5. Guardamos los cambios
       return await this.rewardRepository.update(id, updatedReward);
     } catch (error) {
-      if (error instanceof HttpException) {
+      if (
+        error instanceof HttpException ||
+        error instanceof ForbiddenException
+      ) {
         throw error;
       }
       throw new HttpException(

--- a/goblinhub-api/src/modules/rewards/domain/entities/reward.entity.ts
+++ b/goblinhub-api/src/modules/rewards/domain/entities/reward.entity.ts
@@ -9,5 +9,6 @@ export class Recompensa {
     public tipo: TipoRecompensa,
     public valor_descuento?: number,
     public activa: boolean = true, // Por defecto es activa
+    public id_creador?: string,
   ) {}
 }

--- a/goblinhub-api/src/modules/rewards/domain/repositories/reward.repository.ts
+++ b/goblinhub-api/src/modules/rewards/domain/repositories/reward.repository.ts
@@ -4,7 +4,10 @@ export abstract class RewardRepository {
   abstract findAll(): Promise<Recompensa[]>;
   abstract findById(id: number): Promise<Recompensa | null>;
   abstract findByName(nombre: string): Promise<Recompensa | null>;
-  abstract create(recompensa: Recompensa): Promise<Recompensa>;
+  abstract create(
+    recompensa: Recompensa,
+    id_creador: string,
+  ): Promise<Recompensa>;
   abstract update(
     id: number,
     recompensa: Partial<Recompensa>,

--- a/goblinhub-api/src/modules/rewards/infrastructure/prisma/Reward.repository.ts
+++ b/goblinhub-api/src/modules/rewards/infrastructure/prisma/Reward.repository.ts
@@ -23,10 +23,11 @@ export class RewardPrismaRepository extends RewardRepository {
         ? prismaReward.valor_descuento.toNumber()
         : undefined,
       prismaReward.activa,
+      prismaReward.id_creador ?? undefined,
     );
   }
 
-  async create(reward: Recompensa): Promise<Recompensa> {
+  async create(reward: Recompensa, id_creador: string): Promise<Recompensa> {
     const created = await this.prisma.recompensa.create({
       data: {
         nombre: reward.nombre,
@@ -35,6 +36,7 @@ export class RewardPrismaRepository extends RewardRepository {
         tipo: TipoRecompensaMapper.toPrisma(reward.tipo),
         valor_descuento: reward.valor_descuento,
         activa: reward.activa,
+        id_creador: id_creador,
       },
     });
 

--- a/goblinhub-api/src/modules/rewards/infrastructure/prisma/Reward.repository.ts
+++ b/goblinhub-api/src/modules/rewards/infrastructure/prisma/Reward.repository.ts
@@ -23,7 +23,7 @@ export class RewardPrismaRepository extends RewardRepository {
         ? prismaReward.valor_descuento.toNumber()
         : undefined,
       prismaReward.activa,
-      prismaReward.id_creador ?? undefined,
+      (prismaReward.id_creador as string | null | undefined) ?? undefined,
     );
   }
 

--- a/goblinhub-api/src/modules/rewards/interfaces/controllers/reward.controller.ts
+++ b/goblinhub-api/src/modules/rewards/interfaces/controllers/reward.controller.ts
@@ -32,8 +32,10 @@ import { Recompensa } from '../../domain/entities/reward.entity';
 import { CreateRecompensaDto } from '../../aplication/dtos/create-reward.dto';
 import { UpdateRecompensaDto } from '../../aplication/dtos/update-reward.dto';
 
-// --- Auth ---
 import { SupabaseAuthGuard } from '../../../supabase/guard/supabse-auth.guard';
+import { RolesGuard } from '../../../supabase/guard/roles.guard';
+import { Roles } from '../../../supabase/guard/roles.decorator';
+import { RolUsuario } from '../../../supabase/domain/enums/user.enum';
 import type { AuthenticatedRequest } from '../../../supabase/interfaces/types/authenticated-request.interface';
 
 @ApiTags('rewards') // Agrupa en Swagger
@@ -74,7 +76,8 @@ export class RewardController {
   }
 
   @Post()
-  @UseGuards(SupabaseAuthGuard)
+  @UseGuards(SupabaseAuthGuard, RolesGuard)
+  @Roles(RolUsuario.admin, RolUsuario.empleado)
   @ApiBearerAuth() // Muestra el candado en Swagger
   @ApiOperation({ summary: 'Crear una nueva recompensa (Requiere Auth)' })
   @ApiResponse({ status: 201, description: 'Recompensa creada exitosamente.' })
@@ -89,7 +92,8 @@ export class RewardController {
   }
 
   @Patch(':id')
-  @UseGuards(SupabaseAuthGuard)
+  @UseGuards(SupabaseAuthGuard, RolesGuard)
+  @Roles(RolUsuario.admin, RolUsuario.empleado)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Actualizar una recompensa (Requiere Auth)' })
   @ApiParam({ name: 'id', example: 1 })
@@ -100,11 +104,16 @@ export class RewardController {
   ): Promise<Recompensa> {
     if (!req.user) throw new UnauthorizedException('User not authenticated');
 
-    return await this.updateUseCase.updateReward(id, updateRewardDto);
+    return await this.updateUseCase.updateReward(
+      id,
+      updateRewardDto,
+      req.user.id,
+    );
   }
 
   @Delete(':id')
-  @UseGuards(SupabaseAuthGuard)
+  @UseGuards(SupabaseAuthGuard, RolesGuard)
+  @Roles(RolUsuario.admin)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Eliminar (Soft Delete) una recompensa' })
   @ApiParam({ name: 'id', example: 1 })
@@ -118,6 +127,6 @@ export class RewardController {
   ): Promise<void> {
     if (!req.user) throw new UnauthorizedException('User not authenticated');
 
-    await this.deleteUseCase.softDeleteReward(id);
+    await this.deleteUseCase.softDeleteReward(id, req.user.id);
   }
 }

--- a/goblinhub-api/src/modules/supabase/application/dto/auth.dto.ts
+++ b/goblinhub-api/src/modules/supabase/application/dto/auth.dto.ts
@@ -5,6 +5,7 @@ import {
   IsDateString,
   IsEnum,
   MinLength,
+  Matches,
 } from 'class-validator';
 import { NivelExperiencia } from '../../domain/enums/user.enum';
 
@@ -23,6 +24,11 @@ export class CreateTesruserDto {
   email: string;
 
   @IsString()
+  @MinLength(8)
+  @Matches(/(?=.*[a-z])(?=.*[A-Z])(?=.*\d)/, {
+    message:
+      'The password must contain at least one uppercase letter, one lowercase letter, and one number.',
+  })
   password: string;
 }
 
@@ -31,6 +37,11 @@ export class SignInTestuserDto {
   email: string;
 
   @IsString()
+  @MinLength(8)
+  @Matches(/(?=.*[a-z])(?=.*[A-Z])(?=.*\d)/, {
+    message:
+      'The password must contain at least one uppercase letter, one lowercase letter, and one number.',
+  })
   password: string;
 }
 
@@ -39,7 +50,8 @@ export class SignInDto {
   email: string;
 
   @IsString()
-  @MinLength(6)
+  @MinLength(8)
+  @Matches(/(?=.*[a-z])(?=.*[A-Z])(?=.*\d)/)
   password: string;
 }
 
@@ -49,6 +61,10 @@ export class RegisterUserDto {
 
   @IsString()
   @MinLength(8)
+  @Matches(/(?=.*[a-z])(?=.*[A-Z])(?=.*\d)/, {
+    message:
+      'The password must contain at least one uppercase letter, one lowercase letter, and one number.',
+  })
   password: string;
 
   @IsString()
@@ -84,9 +100,17 @@ export class ResetPasswordDto {
 
   @IsString()
   @MinLength(8)
+  @Matches(/(?=.*[a-z])(?=.*[A-Z])(?=.*\d)/, {
+    message:
+      'The password must contain at least one uppercase letter, one lowercase letter, and one number.',
+  })
   newPassword: string;
 
   @IsString()
   @MinLength(8)
+  @Matches(/(?=.*[a-z])(?=.*[A-Z])(?=.*\d)/, {
+    message:
+      'The password must contain at least one uppercase letter, one lowercase letter, and one number.',
+  })
   confirmPassword: string;
 }

--- a/goblinhub-api/src/modules/supabase/application/use-case/forgot-password.use-case.spec.ts
+++ b/goblinhub-api/src/modules/supabase/application/use-case/forgot-password.use-case.spec.ts
@@ -1,0 +1,46 @@
+import { Logger } from '@nestjs/common';
+import { ForgotPasswordUseCase } from './forgot-password.use-case';
+import { SupabaseClient } from '@supabase/supabase-js';
+
+describe('ForgotPasswordUseCase', () => {
+  let useCase: ForgotPasswordUseCase;
+  let supabase: jest.Mocked<SupabaseClient>;
+
+  beforeEach(() => {
+    jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+
+    supabase = {
+      auth: {
+        resetPasswordForEmail: jest.fn(),
+      },
+    } as unknown as jest.Mocked<SupabaseClient>;
+
+    useCase = new ForgotPasswordUseCase(supabase);
+  });
+
+  it('debe retornar mensaje genérico cuando el email existe', async () => {
+    supabase.auth.resetPasswordForEmail = jest.fn().mockResolvedValue({
+      data: {},
+      error: null,
+    });
+
+    const result = await useCase.forgotPassword('test@email.com');
+
+    expect(result).toEqual({
+      message: 'If the email is registered, you will receive a recovery link.',
+    });
+  });
+
+  it('debe retornar el mismo mensaje genérico incluso si hay error (evita enumeración de usuarios)', async () => {
+    supabase.auth.resetPasswordForEmail = jest.fn().mockResolvedValue({
+      data: null,
+      error: { message: 'User not found' },
+    });
+
+    const result = await useCase.forgotPassword('noexiste@email.com');
+
+    expect(result).toEqual({
+      message: 'If the email is registered, you will receive a recovery link.',
+    });
+  });
+});

--- a/goblinhub-api/src/modules/supabase/application/use-case/forgot-password.use-case.ts
+++ b/goblinhub-api/src/modules/supabase/application/use-case/forgot-password.use-case.ts
@@ -1,8 +1,10 @@
-import { BadRequestException, Inject, Injectable } from '@nestjs/common';
+import { Inject, Injectable, Logger } from '@nestjs/common';
 import { SupabaseClient } from '@supabase/supabase-js';
 
 @Injectable()
 export class ForgotPasswordUseCase {
+  private readonly logger = new Logger(ForgotPasswordUseCase.name);
+
   constructor(
     @Inject('SUPABASE_CLIENT') private readonly supabase: SupabaseClient,
   ) {}
@@ -12,8 +14,11 @@ export class ForgotPasswordUseCase {
       redirectTo: process.env.SUPABASE_RESET_PASSWORD_URL,
     });
     if (error) {
-      throw new BadRequestException(error.message);
+      // Log internally but never expose the error — prevents user enumeration
+      this.logger.warn(`forgot-password silenced error: ${error.message}`);
     }
-    return { message: 'Correo de recuperación enviado' };
+    return {
+      message: 'If the email is registered, you will receive a recovery link.',
+    };
   }
 }

--- a/goblinhub-api/src/modules/supabase/application/use-case/getMe.use-case.spec.ts
+++ b/goblinhub-api/src/modules/supabase/application/use-case/getMe.use-case.spec.ts
@@ -1,0 +1,58 @@
+import { NotFoundException } from '@nestjs/common';
+import { GetMeUseCase } from './getMe.use-case';
+import { UsuarioRepository } from '../../domain/repositories/usuario.repository';
+import { RolUsuario } from '../../domain/enums/user.enum';
+
+describe('GetMeUseCase', () => {
+  let useCase: GetMeUseCase;
+  let usuarioRepo: jest.Mocked<UsuarioRepository>;
+
+  beforeEach(() => {
+    usuarioRepo = {
+      findProfileById: jest.fn(),
+      findRolById: jest.fn(),
+    } as unknown as jest.Mocked<UsuarioRepository>;
+
+    useCase = new GetMeUseCase(usuarioRepo);
+  });
+
+  it('debe retornar el perfil del usuario', async () => {
+    usuarioRepo.findProfileById.mockResolvedValue({
+      nombre: 'Goblin Master',
+      rol: RolUsuario.jugador,
+    });
+
+    const result = await useCase.getMyProfile('user-123', 'test@email.com');
+
+    expect(result).toEqual({
+      id: 'user-123',
+      email: 'test@email.com',
+      nombre: 'Goblin Master',
+      rol: RolUsuario.jugador,
+    });
+  });
+
+  it('debe lanzar NotFoundException si el usuario no existe', async () => {
+    usuarioRepo.findProfileById.mockResolvedValue(null);
+
+    await expect(
+      useCase.getMyProfile('user-999', 'noexiste@email.com'),
+    ).rejects.toThrow(NotFoundException);
+  });
+
+  it('debe funcionar con email undefined', async () => {
+    usuarioRepo.findProfileById.mockResolvedValue({
+      nombre: 'Admin',
+      rol: RolUsuario.admin,
+    });
+
+    const result = await useCase.getMyProfile('user-456', undefined);
+
+    expect(result).toEqual({
+      id: 'user-456',
+      email: undefined,
+      nombre: 'Admin',
+      rol: RolUsuario.admin,
+    });
+  });
+});

--- a/goblinhub-api/src/modules/supabase/application/use-case/getUserProfile.use-case.spec.ts
+++ b/goblinhub-api/src/modules/supabase/application/use-case/getUserProfile.use-case.spec.ts
@@ -1,0 +1,69 @@
+import { UnauthorizedException } from '@nestjs/common';
+import { SupabaseGetUserProfileService } from './getUserProfile.use-case';
+import { SupabaseClient } from '@supabase/supabase-js';
+
+describe('SupabaseGetUserProfileService', () => {
+  let service: SupabaseGetUserProfileService;
+  let supabase: jest.Mocked<SupabaseClient>;
+
+  beforeEach(() => {
+    supabase = {
+      auth: {
+        getUser: jest.fn(),
+      },
+    } as unknown as jest.Mocked<SupabaseClient>;
+
+    service = new SupabaseGetUserProfileService(supabase);
+  });
+
+  it('debe retornar el perfil del usuario si el token es válido', async () => {
+    supabase.auth.getUser = jest.fn().mockResolvedValue({
+      data: {
+        user: {
+          id: 'user-1',
+          email: 'test@email.com',
+          created_at: '2026-01-01',
+        },
+      },
+      error: null,
+    });
+
+    const result = await service.getUserProfile('valid-token');
+
+    expect(result.success).toBe(true);
+    expect(result.user.id).toBe('user-1');
+    expect(result.user.email).toBe('test@email.com');
+  });
+
+  it('debe lanzar UnauthorizedException si supabase retorna error', async () => {
+    supabase.auth.getUser = jest.fn().mockResolvedValue({
+      data: { user: null },
+      error: { message: 'Invalid token' },
+    });
+
+    await expect(service.getUserProfile('bad-token')).rejects.toThrow(
+      UnauthorizedException,
+    );
+  });
+
+  it('debe lanzar UnauthorizedException si no hay datos de usuario', async () => {
+    supabase.auth.getUser = jest.fn().mockResolvedValue({
+      data: { user: null },
+      error: null,
+    });
+
+    await expect(service.getUserProfile('empty-token')).rejects.toThrow(
+      UnauthorizedException,
+    );
+  });
+
+  it('debe lanzar UnauthorizedException si hay un error inesperado', async () => {
+    supabase.auth.getUser = jest
+      .fn()
+      .mockRejectedValue(new Error('Network failure'));
+
+    await expect(service.getUserProfile('token')).rejects.toThrow(
+      UnauthorizedException,
+    );
+  });
+});

--- a/goblinhub-api/src/modules/supabase/application/use-case/login-user.use-case.spec.ts
+++ b/goblinhub-api/src/modules/supabase/application/use-case/login-user.use-case.spec.ts
@@ -1,0 +1,83 @@
+import { BadRequestException } from '@nestjs/common';
+import { SupabaseCreateTestUserService } from './login-user.use-case';
+import { SupabaseClient } from '@supabase/supabase-js';
+
+describe('SupabaseCreateTestUserService', () => {
+  let service: SupabaseCreateTestUserService;
+  let supabase: jest.Mocked<SupabaseClient>;
+
+  beforeEach(() => {
+    supabase = {
+      auth: {
+        signInWithPassword: jest.fn(),
+      },
+    } as unknown as jest.Mocked<SupabaseClient>;
+
+    service = new SupabaseCreateTestUserService(supabase);
+  });
+
+  describe('signInTestuser', () => {
+    it('debe retornar sesión completa si el login es exitoso', async () => {
+      supabase.auth.signInWithPassword = jest.fn().mockResolvedValue({
+        data: {
+          user: { id: 'user-1', email: 'test@email.com' },
+          session: {
+            access_token: 'access-tok',
+            refresh_token: 'refresh-tok',
+          },
+        },
+        error: null,
+      });
+
+      const result = await service.signInTestuser(
+        'test@email.com',
+        'Password1',
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.access_token).toBe('access-tok');
+      expect(result.refreshToken).toBe('refresh-tok');
+    });
+
+    it('debe lanzar BadRequestException si supabase retorna error', async () => {
+      supabase.auth.signInWithPassword = jest.fn().mockResolvedValue({
+        data: { session: null, user: null },
+        error: { message: 'Invalid credentials' },
+      });
+
+      await expect(
+        service.signInTestuser('test@email.com', 'Wrong1234'),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('debe lanzar BadRequestException si no se crea sesión', async () => {
+      supabase.auth.signInWithPassword = jest.fn().mockResolvedValue({
+        data: { session: null, user: { id: 'user-1' } },
+        error: null,
+      });
+
+      await expect(
+        service.signInTestuser('test@email.com', 'Password1'),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('debe lanzar BadRequestException si ocurre un error inesperado', async () => {
+      supabase.auth.signInWithPassword = jest
+        .fn()
+        .mockRejectedValue(new Error('Network error'));
+
+      await expect(
+        service.signInTestuser('test@email.com', 'Password1'),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('listAuthUsers', () => {
+    it('debe retornar un mensaje informativo', () => {
+      const result = service.listAuthUsers();
+
+      expect(result.success).toBe(true);
+      expect(result.message).toContain('admin access');
+    });
+  });
+});

--- a/goblinhub-api/src/modules/supabase/application/use-case/refreshT.use-case.spec.ts
+++ b/goblinhub-api/src/modules/supabase/application/use-case/refreshT.use-case.spec.ts
@@ -1,0 +1,56 @@
+import { UnauthorizedException } from '@nestjs/common';
+import { SupabaseRefreshTokenService } from './refreshT.use-case';
+import { SupabaseClient } from '@supabase/supabase-js';
+
+describe('SupabaseRefreshTokenService', () => {
+  let service: SupabaseRefreshTokenService;
+  let supabase: jest.Mocked<SupabaseClient>;
+
+  beforeEach(() => {
+    supabase = {
+      auth: {
+        refreshSession: jest.fn(),
+      },
+    } as unknown as jest.Mocked<SupabaseClient>;
+
+    service = new SupabaseRefreshTokenService(supabase);
+  });
+
+  it('debe retornar la sesión renovada', async () => {
+    const mockSession = {
+      access_token: 'new-access',
+      refresh_token: 'new-refresh',
+    };
+
+    supabase.auth.refreshSession = jest.fn().mockResolvedValue({
+      data: mockSession,
+      error: null,
+    });
+
+    const result = await service.refreshToken('old-refresh-token');
+
+    expect(result.success).toBe(true);
+    expect(result.session).toEqual(mockSession);
+  });
+
+  it('debe lanzar UnauthorizedException si supabase retorna error', async () => {
+    supabase.auth.refreshSession = jest.fn().mockResolvedValue({
+      data: null,
+      error: { message: 'Token expired' },
+    });
+
+    await expect(service.refreshToken('expired-token')).rejects.toThrow(
+      UnauthorizedException,
+    );
+  });
+
+  it('debe lanzar UnauthorizedException si ocurre una excepción inesperada', async () => {
+    supabase.auth.refreshSession = jest
+      .fn()
+      .mockRejectedValue(new Error('Network error'));
+
+    await expect(service.refreshToken('any-token')).rejects.toThrow(
+      UnauthorizedException,
+    );
+  });
+});

--- a/goblinhub-api/src/modules/supabase/application/use-case/register-user.use-case.spec.ts
+++ b/goblinhub-api/src/modules/supabase/application/use-case/register-user.use-case.spec.ts
@@ -1,0 +1,124 @@
+import {
+  BadRequestException,
+  InternalServerErrorException,
+  Logger,
+} from '@nestjs/common';
+import { SupabaseRegisterUserService } from './register-user.use-case';
+import { SupabaseClient } from '@supabase/supabase-js';
+import { PrismaService } from '../../../../connect/prisma.service';
+import { RegisterUserDto } from '../dto/auth.dto';
+import { NivelExperiencia } from '../../domain/enums/user.enum';
+
+describe('SupabaseRegisterUserService', () => {
+  let service: SupabaseRegisterUserService;
+  let supabase: jest.Mocked<SupabaseClient>;
+  let supabaseAdmin: jest.Mocked<SupabaseClient>;
+  let prisma: jest.Mocked<PrismaService>;
+  let adminMock: { deleteUser: jest.Mock };
+
+  const mockDto: RegisterUserDto = {
+    email: 'nuevo@email.com',
+    password: 'Password1',
+    nombre: 'Goblin',
+    apellidos: 'Verde',
+    telefono: '123456789',
+    fecha_nacimiento: '2000-01-15',
+    bio: 'Soy un goblin',
+    nivel_experiencia: NivelExperiencia.novato,
+  };
+
+  beforeEach(() => {
+    supabase = {
+      auth: {
+        signUp: jest.fn(),
+      },
+    } as unknown as jest.Mocked<SupabaseClient>;
+
+    adminMock = { deleteUser: jest.fn() };
+
+    supabaseAdmin = {
+      auth: {
+        admin: adminMock,
+      },
+    } as unknown as jest.Mocked<SupabaseClient>;
+
+    prisma = {
+      usuario: {
+        create: jest.fn(),
+      },
+    } as unknown as jest.Mocked<PrismaService>;
+
+    jest.spyOn(Logger.prototype, 'error').mockImplementation();
+
+    service = new SupabaseRegisterUserService(supabase, supabaseAdmin, prisma);
+  });
+
+  it('debe registrar un usuario exitosamente', async () => {
+    supabase.auth.signUp = jest.fn().mockResolvedValue({
+      data: {
+        user: { id: 'supa-uuid-1', email: 'nuevo@email.com' },
+        session: { access_token: 'tok' },
+      },
+      error: null,
+    });
+
+    (prisma.usuario.create as jest.Mock).mockResolvedValue({
+      id_usuario: 'supa-uuid-1',
+      nombre: 'Goblin',
+      apellidos: 'Verde',
+      rol: 'jugador',
+      nivel_experiencia: NivelExperiencia.novato,
+      created_at: new Date(),
+    });
+
+    const result = await service.register(mockDto);
+
+    expect(result.success).toBe(true);
+    expect(result.user.id).toBe('supa-uuid-1');
+    expect(result.user.email).toBe('nuevo@email.com');
+  });
+
+  it('debe lanzar BadRequestException si supabase signUp falla', async () => {
+    supabase.auth.signUp = jest.fn().mockResolvedValue({
+      data: { user: null, session: null },
+      error: { message: 'Email already registered' },
+    });
+
+    await expect(service.register(mockDto)).rejects.toThrow(
+      BadRequestException,
+    );
+  });
+
+  it('debe lanzar BadRequestException si no se crea el usuario en supabase', async () => {
+    supabase.auth.signUp = jest.fn().mockResolvedValue({
+      data: { user: null, session: null },
+      error: null,
+    });
+
+    await expect(service.register(mockDto)).rejects.toThrow(
+      BadRequestException,
+    );
+  });
+
+  it('debe hacer rollback (eliminar usuario de Supabase) si falla Prisma', async () => {
+    supabase.auth.signUp = jest.fn().mockResolvedValue({
+      data: {
+        user: { id: 'supa-uuid-2', email: 'nuevo@email.com' },
+        session: null,
+      },
+      error: null,
+    });
+
+    (prisma.usuario.create as jest.Mock).mockRejectedValue(
+      new Error('Unique constraint failed'),
+    );
+
+    adminMock.deleteUser.mockResolvedValue({});
+
+    await expect(service.register(mockDto)).rejects.toThrow(
+      InternalServerErrorException,
+    );
+
+    expect(adminMock.deleteUser).toHaveBeenCalledWith('supa-uuid-2');
+  });
+});

--- a/goblinhub-api/src/modules/supabase/application/use-case/register-user.use-case.ts
+++ b/goblinhub-api/src/modules/supabase/application/use-case/register-user.use-case.ts
@@ -16,6 +16,8 @@ export class SupabaseRegisterUserService {
 
   constructor(
     @Inject('SUPABASE_CLIENT') private readonly supabase: SupabaseClient,
+    @Inject('SUPABASE_ADMIN_CLIENT')
+    private readonly supabaseAdmin: SupabaseClient,
     private readonly prisma: PrismaService,
   ) {}
 
@@ -63,16 +65,12 @@ export class SupabaseRegisterUserService {
         session: data.session,
       };
     } catch (prismaError) {
-      // Rollback: delete user from Supabase to avoid inconsistent state
-      // NOTE: requires SUPABASE_SERVICE_ROLE_KEY to use auth.admin.deleteUser
+      // Rollback automático: eliminar usuario de Supabase
+      await this.supabaseAdmin.auth.admin.deleteUser(supabaseUserId);
       this.logger.error(
-        `Failed to create profile in DB for user ${supabaseUserId}. ` +
-          `User was created in Supabase Auth. Manual rollback required.`,
-        prismaError,
+        `Rollback: usuario ${supabaseUserId} eliminado de Supabase Auth. Causa: ${String(prismaError)}`,
       );
-      throw new InternalServerErrorException(
-        'Failed to save user profile. Please contact support.',
-      );
+      throw new InternalServerErrorException('Failed to save user profile.');
     }
   }
 }

--- a/goblinhub-api/src/modules/supabase/application/use-case/reset-password.use-case.spec.ts
+++ b/goblinhub-api/src/modules/supabase/application/use-case/reset-password.use-case.spec.ts
@@ -1,0 +1,94 @@
+import { BadRequestException, UnauthorizedException } from '@nestjs/common';
+import { ResetPasswordUseCase } from './reset-password.use-case';
+import { SupabaseClient } from '@supabase/supabase-js';
+
+describe('ResetPasswordUseCase', () => {
+  let useCase: ResetPasswordUseCase;
+  let supabase: jest.Mocked<SupabaseClient>;
+  let supabaseAdmin: jest.Mocked<SupabaseClient>;
+  let adminMock: { updateUserById: jest.Mock };
+
+  beforeEach(() => {
+    supabase = {
+      auth: {
+        getUser: jest.fn(),
+      },
+    } as unknown as jest.Mocked<SupabaseClient>;
+
+    adminMock = { updateUserById: jest.fn() };
+
+    supabaseAdmin = {
+      auth: {
+        admin: adminMock,
+      },
+    } as unknown as jest.Mocked<SupabaseClient>;
+
+    useCase = new ResetPasswordUseCase(supabase, supabaseAdmin);
+  });
+
+  it('debe actualizar la contraseña correctamente', async () => {
+    supabase.auth.getUser = jest.fn().mockResolvedValue({
+      data: { user: { id: 'user-123' } },
+      error: null,
+    });
+
+    adminMock.updateUserById.mockResolvedValue({
+      data: { user: {} },
+      error: null,
+    });
+
+    const result = await useCase.resetPassword(
+      'valid-token',
+      'NewPass123',
+      'NewPass123',
+    );
+
+    expect(result).toEqual({
+      message: 'Contraseña actualizada correctamente',
+    });
+  });
+
+  it('debe lanzar BadRequestException si las contraseñas no coinciden', async () => {
+    await expect(
+      useCase.resetPassword('valid-token', 'NewPass123', 'Different1'),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  it('debe lanzar UnauthorizedException si el token es inválido', async () => {
+    supabase.auth.getUser = jest.fn().mockResolvedValue({
+      data: { user: null },
+      error: { message: 'Invalid token' },
+    });
+
+    await expect(
+      useCase.resetPassword('bad-token', 'NewPass123', 'NewPass123'),
+    ).rejects.toThrow(UnauthorizedException);
+  });
+
+  it('debe lanzar UnauthorizedException si no se encuentra el usuario', async () => {
+    supabase.auth.getUser = jest.fn().mockResolvedValue({
+      data: { user: null },
+      error: null,
+    });
+
+    await expect(
+      useCase.resetPassword('token-no-user', 'NewPass123', 'NewPass123'),
+    ).rejects.toThrow(UnauthorizedException);
+  });
+
+  it('debe lanzar BadRequestException si falla la actualización', async () => {
+    supabase.auth.getUser = jest.fn().mockResolvedValue({
+      data: { user: { id: 'user-123' } },
+      error: null,
+    });
+
+    adminMock.updateUserById.mockResolvedValue({
+      data: null,
+      error: { message: 'Update failed' },
+    });
+
+    await expect(
+      useCase.resetPassword('valid-token', 'NewPass123', 'NewPass123'),
+    ).rejects.toThrow(BadRequestException);
+  });
+});

--- a/goblinhub-api/src/modules/supabase/application/use-case/reset-password.use-case.ts
+++ b/goblinhub-api/src/modules/supabase/application/use-case/reset-password.use-case.ts
@@ -4,11 +4,13 @@ import {
   Injectable,
   UnauthorizedException,
 } from '@nestjs/common';
-import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { SupabaseClient } from '@supabase/supabase-js';
 
 @Injectable()
 export class ResetPasswordUseCase {
   constructor(
+    @Inject('SUPABASE_CLIENT')
+    private readonly supabase: SupabaseClient,
     @Inject('SUPABASE_ADMIN_CLIENT')
     private readonly supabaseAdmin: SupabaseClient,
   ) {}
@@ -22,31 +24,17 @@ export class ResetPasswordUseCase {
       throw new BadRequestException('Las contraseñas no coinciden');
     }
 
-    const supabaseUrl = process.env.SUPABASE_URL;
-    const supabaseAnonKey = process.env.SUPABASE_ANON_KEY;
-
-    if (!supabaseUrl || !supabaseAnonKey) {
-      throw new BadRequestException('Configuración de Supabase incompleta');
-    }
-
-    // Paso 1: usar el anon client para validar el recovery JWT.
-    // supabase.auth.getUser(jwt) envía GET /auth/v1/user con
-    // Authorization: Bearer <jwt> — funciona correctamente con tokens de recovery.
-    const anonClient = createClient(supabaseUrl, supabaseAnonKey, {
-      auth: { autoRefreshToken: false, persistSession: false },
-    });
-
+    // Paso 1: validar el recovery JWT con el anon client inyectado.
     const {
       data: { user },
       error: getUserError,
-    } = await anonClient.auth.getUser(accessToken);
+    } = await this.supabase.auth.getUser(accessToken);
 
     if (getUserError || !user) {
       throw new UnauthorizedException('Token inválido o expirado');
     }
 
     // Paso 2: actualizar la contraseña con el admin client.
-    // Esta es la única vía 100% confiable desde un backend NestJS.
     const { error: updateError } =
       await this.supabaseAdmin.auth.admin.updateUserById(user.id, {
         password: newPassword,

--- a/goblinhub-api/src/modules/supabase/application/use-case/signin.use-case.spec.ts
+++ b/goblinhub-api/src/modules/supabase/application/use-case/signin.use-case.spec.ts
@@ -1,0 +1,63 @@
+import { BadRequestException } from '@nestjs/common';
+import { SignInUseCase } from './signin.use-case';
+import { SupabaseClient } from '@supabase/supabase-js';
+
+describe('SignInUseCase', () => {
+  let useCase: SignInUseCase;
+  let supabase: jest.Mocked<SupabaseClient>;
+
+  beforeEach(() => {
+    supabase = {
+      auth: {
+        signInWithPassword: jest.fn(),
+      },
+    } as unknown as jest.Mocked<SupabaseClient>;
+
+    useCase = new SignInUseCase(supabase);
+  });
+
+  it('debe retornar access_token y refresh_token si el login es exitoso', async () => {
+    supabase.auth.signInWithPassword = jest.fn().mockResolvedValue({
+      data: {
+        session: {
+          access_token: 'access-123',
+          refresh_token: 'refresh-456',
+        },
+        user: { id: 'user-1' },
+      },
+      error: null,
+    });
+
+    const result = await useCase.signInWithCredentials(
+      'test@email.com',
+      'Password1',
+    );
+
+    expect(result).toEqual({
+      access_token: 'access-123',
+      refresh_token: 'refresh-456',
+    });
+  });
+
+  it('debe lanzar BadRequestException si supabase retorna error', async () => {
+    supabase.auth.signInWithPassword = jest.fn().mockResolvedValue({
+      data: { session: null, user: null },
+      error: { message: 'Invalid login credentials' },
+    });
+
+    await expect(
+      useCase.signInWithCredentials('test@email.com', 'Wrong1234'),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  it('debe lanzar BadRequestException si no se crea sesión', async () => {
+    supabase.auth.signInWithPassword = jest.fn().mockResolvedValue({
+      data: { session: null, user: { id: 'user-1' } },
+      error: null,
+    });
+
+    await expect(
+      useCase.signInWithCredentials('test@email.com', 'Password1'),
+    ).rejects.toThrow(BadRequestException);
+  });
+});

--- a/goblinhub-api/src/modules/supabase/application/use-case/validationT.use-case.spec.ts
+++ b/goblinhub-api/src/modules/supabase/application/use-case/validationT.use-case.spec.ts
@@ -1,0 +1,65 @@
+import { UnauthorizedException } from '@nestjs/common';
+import { SupabaseValidationTokenService } from './validationT.use-case';
+import { SupabaseClient } from '@supabase/supabase-js';
+
+describe('SupabaseValidationTokenService', () => {
+  let service: SupabaseValidationTokenService;
+  let supabase: jest.Mocked<SupabaseClient>;
+
+  beforeEach(() => {
+    supabase = {
+      auth: {
+        getUser: jest.fn(),
+      },
+    } as unknown as jest.Mocked<SupabaseClient>;
+
+    service = new SupabaseValidationTokenService(supabase);
+  });
+
+  it('debe retornar éxito y usuario si el token es válido', async () => {
+    const mockUser = { id: 'user-1', email: 'test@email.com' };
+
+    supabase.auth.getUser = jest.fn().mockResolvedValue({
+      data: { user: mockUser },
+      error: null,
+    });
+
+    const result = await service.validtoken('valid-token');
+
+    expect(result.success).toBe(true);
+    expect(result.user).toEqual(mockUser);
+    expect(result.message).toBe('Token is valid');
+  });
+
+  it('debe lanzar UnauthorizedException si supabase retorna error', async () => {
+    supabase.auth.getUser = jest.fn().mockResolvedValue({
+      data: { user: null },
+      error: { message: 'Token expired' },
+    });
+
+    await expect(service.validtoken('expired-token')).rejects.toThrow(
+      UnauthorizedException,
+    );
+  });
+
+  it('debe lanzar UnauthorizedException si no hay usuario', async () => {
+    supabase.auth.getUser = jest.fn().mockResolvedValue({
+      data: { user: null },
+      error: null,
+    });
+
+    await expect(service.validtoken('no-user-token')).rejects.toThrow(
+      UnauthorizedException,
+    );
+  });
+
+  it('debe lanzar UnauthorizedException si ocurre una excepción', async () => {
+    supabase.auth.getUser = jest
+      .fn()
+      .mockRejectedValue(new Error('Network error'));
+
+    await expect(service.validtoken('any-token')).rejects.toThrow(
+      UnauthorizedException,
+    );
+  });
+});

--- a/goblinhub-api/src/modules/supabase/guard/roles.guard.spec.ts
+++ b/goblinhub-api/src/modules/supabase/guard/roles.guard.spec.ts
@@ -1,0 +1,114 @@
+import { ForbiddenException, Logger } from '@nestjs/common';
+import { ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { RolesGuard } from './roles.guard';
+import { UsuarioRepository } from '../domain/repositories/usuario.repository';
+import { RolUsuario } from '../domain/enums/user.enum';
+
+describe('RolesGuard', () => {
+  let guard: RolesGuard;
+  let reflector: jest.Mocked<Reflector>;
+  let usuarioRepo: jest.Mocked<UsuarioRepository>;
+
+  const createMockContext = (userId?: string): ExecutionContext => {
+    const request = {
+      user: userId ? { id: userId } : undefined,
+    };
+
+    return {
+      switchToHttp: () => ({
+        getRequest: () => request,
+      }),
+      getHandler: () => jest.fn(),
+      getClass: () => jest.fn(),
+    } as unknown as ExecutionContext;
+  };
+
+  beforeEach(() => {
+    reflector = {
+      getAllAndOverride: jest.fn(),
+    } as unknown as jest.Mocked<Reflector>;
+
+    usuarioRepo = {
+      findRolById: jest.fn(),
+      findProfileById: jest.fn(),
+    } as unknown as jest.Mocked<UsuarioRepository>;
+
+    jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+
+    guard = new RolesGuard(reflector, usuarioRepo);
+  });
+
+  it('debe permitir acceso si no hay roles requeridos (@Roles no aplicado)', async () => {
+    reflector.getAllAndOverride.mockReturnValue(undefined);
+
+    const context = createMockContext('user-1');
+    const result = await guard.canActivate(context);
+
+    expect(result).toBe(true);
+  });
+
+  it('debe permitir acceso si los roles requeridos es un arreglo vacío', async () => {
+    reflector.getAllAndOverride.mockReturnValue([]);
+
+    const context = createMockContext('user-1');
+    const result = await guard.canActivate(context);
+
+    expect(result).toBe(true);
+  });
+
+  it('debe permitir acceso si el usuario tiene el rol requerido', async () => {
+    reflector.getAllAndOverride.mockReturnValue([RolUsuario.admin]);
+    usuarioRepo.findRolById.mockResolvedValue(RolUsuario.admin);
+
+    const context = createMockContext('admin-1');
+    const result = await guard.canActivate(context);
+
+    expect(result).toBe(true);
+  });
+
+  it('debe lanzar ForbiddenException si el usuario no tiene el rol requerido', async () => {
+    reflector.getAllAndOverride.mockReturnValue([RolUsuario.admin]);
+    usuarioRepo.findRolById.mockResolvedValue(RolUsuario.jugador);
+
+    const context = createMockContext('jugador-1');
+
+    await expect(guard.canActivate(context)).rejects.toThrow(
+      ForbiddenException,
+    );
+  });
+
+  it('debe lanzar ForbiddenException si no se encuentra identidad del usuario', async () => {
+    reflector.getAllAndOverride.mockReturnValue([RolUsuario.admin]);
+
+    const context = createMockContext(undefined);
+
+    await expect(guard.canActivate(context)).rejects.toThrow(
+      ForbiddenException,
+    );
+  });
+
+  it('debe lanzar ForbiddenException si el usuario no existe en la BD', async () => {
+    reflector.getAllAndOverride.mockReturnValue([RolUsuario.admin]);
+    usuarioRepo.findRolById.mockResolvedValue(null);
+
+    const context = createMockContext('nonexistent-1');
+
+    await expect(guard.canActivate(context)).rejects.toThrow(
+      ForbiddenException,
+    );
+  });
+
+  it('debe permitir acceso si el usuario tiene uno de múltiples roles requeridos', async () => {
+    reflector.getAllAndOverride.mockReturnValue([
+      RolUsuario.admin,
+      RolUsuario.empleado,
+    ]);
+    usuarioRepo.findRolById.mockResolvedValue(RolUsuario.empleado);
+
+    const context = createMockContext('emp-1');
+    const result = await guard.canActivate(context);
+
+    expect(result).toBe(true);
+  });
+});

--- a/goblinhub-api/src/modules/supabase/guard/supabse-auth.guard.spec.ts
+++ b/goblinhub-api/src/modules/supabase/guard/supabse-auth.guard.spec.ts
@@ -1,0 +1,137 @@
+import { Logger, UnauthorizedException } from '@nestjs/common';
+import { ExecutionContext } from '@nestjs/common';
+import { SupabaseAuthGuard } from './supabse-auth.guard';
+import { SupabaseValidationTokenService } from '../application/use-case/validationT.use-case';
+import { User } from '@supabase/supabase-js';
+
+const mockSupabaseUser: User = {
+  id: 'user-1',
+  email: 'test@email.com',
+  aud: 'authenticated',
+  role: 'authenticated',
+  app_metadata: {},
+  user_metadata: {},
+  identities: [],
+  created_at: '2026-01-01T00:00:00Z',
+} as User;
+
+describe('SupabaseAuthGuard', () => {
+  let guard: SupabaseAuthGuard;
+  let validationService: jest.Mocked<SupabaseValidationTokenService>;
+
+  const createMockContext = (authHeader?: string): ExecutionContext => {
+    const request = {
+      headers: {
+        authorization: authHeader,
+      },
+    };
+
+    return {
+      switchToHttp: () => ({
+        getRequest: () => request,
+      }),
+    } as unknown as ExecutionContext;
+  };
+
+  beforeEach(() => {
+    jest.spyOn(Logger.prototype, 'log').mockImplementation();
+    jest.spyOn(Logger.prototype, 'error').mockImplementation();
+
+    validationService = {
+      validtoken: jest.fn(),
+    } as unknown as jest.Mocked<SupabaseValidationTokenService>;
+
+    guard = new SupabaseAuthGuard(validationService);
+  });
+
+  it('debe permitir acceso si el token es válido', async () => {
+    validationService.validtoken.mockResolvedValue({
+      success: true,
+      user: mockSupabaseUser,
+      message: 'Token is valid',
+    });
+
+    const context = createMockContext('Bearer valid-token');
+    const result = await guard.canActivate(context);
+
+    expect(result).toBe(true);
+  });
+
+  it('debe lanzar UnauthorizedException si no hay header de autorización', async () => {
+    const context = createMockContext(undefined);
+
+    await expect(guard.canActivate(context)).rejects.toThrow(
+      UnauthorizedException,
+    );
+  });
+
+  it('debe lanzar UnauthorizedException si el header no es string', async () => {
+    const context = {
+      switchToHttp: () => ({
+        getRequest: () => ({
+          headers: { authorization: 123 },
+        }),
+      }),
+    } as unknown as ExecutionContext;
+
+    await expect(guard.canActivate(context)).rejects.toThrow(
+      UnauthorizedException,
+    );
+  });
+
+  it('debe lanzar UnauthorizedException si el token falta del header Bearer', async () => {
+    const context = createMockContext('Bearer');
+
+    await expect(guard.canActivate(context)).rejects.toThrow(
+      UnauthorizedException,
+    );
+  });
+
+  it('debe lanzar UnauthorizedException si la validación retorna success=false', async () => {
+    validationService.validtoken.mockResolvedValue({
+      success: false,
+      user: null as unknown as User,
+      message: 'Failed',
+    });
+
+    const context = createMockContext('Bearer some-token');
+
+    await expect(guard.canActivate(context)).rejects.toThrow(
+      UnauthorizedException,
+    );
+  });
+
+  it('debe lanzar UnauthorizedException si el servicio de validación lanza error', async () => {
+    validationService.validtoken.mockRejectedValue(
+      new Error('Service unavailable'),
+    );
+
+    const context = createMockContext('Bearer some-token');
+
+    await expect(guard.canActivate(context)).rejects.toThrow(
+      UnauthorizedException,
+    );
+  });
+
+  it('debe asignar el usuario al request cuando es válido', async () => {
+    validationService.validtoken.mockResolvedValue({
+      success: true,
+      user: mockSupabaseUser,
+      message: 'Token is valid',
+    });
+
+    const request: { headers: { authorization: string }; user?: unknown } = {
+      headers: { authorization: 'Bearer valid-token' },
+    };
+
+    const context = {
+      switchToHttp: () => ({
+        getRequest: () => request,
+      }),
+    } as unknown as ExecutionContext;
+
+    await guard.canActivate(context);
+
+    expect(request.user).toEqual(mockSupabaseUser);
+  });
+});

--- a/goblinhub-api/src/modules/supabase/infrastructure/controller/supabase-auth.controller.spec.ts
+++ b/goblinhub-api/src/modules/supabase/infrastructure/controller/supabase-auth.controller.spec.ts
@@ -10,7 +10,8 @@ import { SignInUseCase } from '../../application/use-case/signin.use-case';
 import { ForgotPasswordUseCase } from '../../application/use-case/forgot-password.use-case';
 import { ResetPasswordUseCase } from '../../application/use-case/reset-password.use-case';
 import { AuthenticatedRequest } from '../../interfaces/types/authenticated-request.interface';
-import { RolUsuario } from '../../domain/enums/user.enum';
+import { RolUsuario, NivelExperiencia } from '../../domain/enums/user.enum';
+import { Session, User } from '@supabase/supabase-js';
 
 describe('SupabaseAuthController', () => {
   let controller: SupabaseAuthController;
@@ -92,8 +93,20 @@ describe('SupabaseAuthController', () => {
 
   describe('signUp', () => {
     it('debe delegar al registerUserService', async () => {
-      const mockResponse = { success: true, message: 'User registered' };
-      registerUserService.register.mockResolvedValue(mockResponse as any);
+      registerUserService.register.mockResolvedValue({
+        success: true,
+        message: 'User registered successfully',
+        user: {
+          id: 'user-1',
+          email: 'new@email.com',
+          nombre: 'Test',
+          apellidos: 'User',
+          rol: RolUsuario.jugador,
+          nivel_experiencia: NivelExperiencia.novato,
+          created_at: new Date(),
+        },
+        session: null,
+      });
 
       const result = await controller.signUp({
         email: 'new@email.com',
@@ -103,20 +116,22 @@ describe('SupabaseAuthController', () => {
         fecha_nacimiento: '2000-01-01',
       });
 
-      expect(result).toEqual(mockResponse);
+      expect(result.success).toBe(true);
     });
   });
 
   describe('refreshToken', () => {
     it('debe delegar al refreshService', async () => {
-      const mockSession = { success: true, session: {} };
-      refreshService.refreshToken.mockResolvedValue(mockSession as any);
+      refreshService.refreshToken.mockResolvedValue({
+        success: true,
+        session: { user: null, session: null },
+      });
 
       const result = await controller.refreshToken({
         refreshToken: 'ref-tok',
       });
 
-      expect(result).toEqual(mockSession);
+      expect(result.success).toBe(true);
     });
   });
 
@@ -129,11 +144,14 @@ describe('SupabaseAuthController', () => {
 
       const mockProfile = {
         success: true,
-        user: { id: 'user-1', email: 'test@email.com' },
+        user: {
+          id: 'user-1',
+          email: 'test@email.com',
+          createdAt: '2026-01-01',
+        },
+        message: 'User profile retrieved successfully',
       };
-      getUserProfileService.getUserProfile.mockResolvedValue(
-        mockProfile as any,
-      );
+      getUserProfileService.getUserProfile.mockResolvedValue(mockProfile);
 
       const result = await controller.getProfile(req);
       expect(result).toEqual(mockProfile);
@@ -259,12 +277,12 @@ describe('SupabaseAuthController', () => {
 
       createTestUserService.signInTestuser.mockResolvedValue({
         success: true,
-        user: {},
-        session: {},
+        user: {} as User,
+        session: {} as Session,
         access_token: 'tok',
         refreshToken: 'ref',
         message: 'Login successful',
-      } as any);
+      });
 
       const result = await controller.signInTestestuser({
         email: 'admin@email.com',

--- a/goblinhub-api/src/modules/supabase/infrastructure/controller/supabase-auth.controller.spec.ts
+++ b/goblinhub-api/src/modules/supabase/infrastructure/controller/supabase-auth.controller.spec.ts
@@ -1,0 +1,292 @@
+import { UnauthorizedException } from '@nestjs/common';
+import { SupabaseAuthController } from './supabase-auth.controller';
+import { SupabaseValidationTokenService } from '../../application/use-case/validationT.use-case';
+import { SupabaseRefreshTokenService } from '../../application/use-case/refreshT.use-case';
+import { SupabaseGetUserProfileService } from '../../application/use-case/getUserProfile.use-case';
+import { SupabaseCreateTestUserService } from '../../application/use-case/login-user.use-case';
+import { SupabaseRegisterUserService } from '../../application/use-case/register-user.use-case';
+import { GetMeUseCase } from '../../application/use-case/getMe.use-case';
+import { SignInUseCase } from '../../application/use-case/signin.use-case';
+import { ForgotPasswordUseCase } from '../../application/use-case/forgot-password.use-case';
+import { ResetPasswordUseCase } from '../../application/use-case/reset-password.use-case';
+import { AuthenticatedRequest } from '../../interfaces/types/authenticated-request.interface';
+import { RolUsuario } from '../../domain/enums/user.enum';
+
+describe('SupabaseAuthController', () => {
+  let controller: SupabaseAuthController;
+  let validationService: jest.Mocked<SupabaseValidationTokenService>;
+  let refreshService: jest.Mocked<SupabaseRefreshTokenService>;
+  let getUserProfileService: jest.Mocked<SupabaseGetUserProfileService>;
+  let createTestUserService: jest.Mocked<SupabaseCreateTestUserService>;
+  let registerUserService: jest.Mocked<SupabaseRegisterUserService>;
+  let getMeUseCase: jest.Mocked<GetMeUseCase>;
+  let signInUseCase: jest.Mocked<SignInUseCase>;
+  let forgotPasswordUseCase: jest.Mocked<ForgotPasswordUseCase>;
+  let resetPasswordUseCase: jest.Mocked<ResetPasswordUseCase>;
+
+  beforeEach(() => {
+    validationService = {
+      validtoken: jest.fn(),
+    } as unknown as jest.Mocked<SupabaseValidationTokenService>;
+
+    refreshService = {
+      refreshToken: jest.fn(),
+    } as unknown as jest.Mocked<SupabaseRefreshTokenService>;
+
+    getUserProfileService = {
+      getUserProfile: jest.fn(),
+    } as unknown as jest.Mocked<SupabaseGetUserProfileService>;
+
+    createTestUserService = {
+      signInTestuser: jest.fn(),
+    } as unknown as jest.Mocked<SupabaseCreateTestUserService>;
+
+    registerUserService = {
+      register: jest.fn(),
+    } as unknown as jest.Mocked<SupabaseRegisterUserService>;
+
+    getMeUseCase = {
+      getMyProfile: jest.fn(),
+    } as unknown as jest.Mocked<GetMeUseCase>;
+
+    signInUseCase = {
+      signInWithCredentials: jest.fn(),
+    } as unknown as jest.Mocked<SignInUseCase>;
+
+    forgotPasswordUseCase = {
+      forgotPassword: jest.fn(),
+    } as unknown as jest.Mocked<ForgotPasswordUseCase>;
+
+    resetPasswordUseCase = {
+      resetPassword: jest.fn(),
+    } as unknown as jest.Mocked<ResetPasswordUseCase>;
+
+    controller = new SupabaseAuthController(
+      validationService,
+      refreshService,
+      getUserProfileService,
+      createTestUserService,
+      registerUserService,
+      getMeUseCase,
+      signInUseCase,
+      forgotPasswordUseCase,
+      resetPasswordUseCase,
+    );
+  });
+
+  describe('signIn', () => {
+    it('debe delegar al signInUseCase', async () => {
+      signInUseCase.signInWithCredentials.mockResolvedValue({
+        access_token: 'tok',
+        refresh_token: 'ref',
+      });
+
+      const result = await controller.signIn({
+        email: 'test@email.com',
+        password: 'Password1',
+      });
+
+      expect(result).toEqual({ access_token: 'tok', refresh_token: 'ref' });
+    });
+  });
+
+  describe('signUp', () => {
+    it('debe delegar al registerUserService', async () => {
+      const mockResponse = { success: true, message: 'User registered' };
+      registerUserService.register.mockResolvedValue(mockResponse as any);
+
+      const result = await controller.signUp({
+        email: 'new@email.com',
+        password: 'Password1',
+        nombre: 'Test',
+        apellidos: 'User',
+        fecha_nacimiento: '2000-01-01',
+      });
+
+      expect(result).toEqual(mockResponse);
+    });
+  });
+
+  describe('refreshToken', () => {
+    it('debe delegar al refreshService', async () => {
+      const mockSession = { success: true, session: {} };
+      refreshService.refreshToken.mockResolvedValue(mockSession as any);
+
+      const result = await controller.refreshToken({
+        refreshToken: 'ref-tok',
+      });
+
+      expect(result).toEqual(mockSession);
+    });
+  });
+
+  describe('getProfile', () => {
+    it('debe retornar el perfil del usuario autenticado', async () => {
+      const req = {
+        user: { id: 'user-1', email: 'test@email.com' },
+        headers: { authorization: 'Bearer valid-token' },
+      } as unknown as AuthenticatedRequest;
+
+      const mockProfile = {
+        success: true,
+        user: { id: 'user-1', email: 'test@email.com' },
+      };
+      getUserProfileService.getUserProfile.mockResolvedValue(
+        mockProfile as any,
+      );
+
+      const result = await controller.getProfile(req);
+      expect(result).toEqual(mockProfile);
+    });
+
+    it('debe lanzar UnauthorizedException si no hay usuario', async () => {
+      const req = {
+        user: undefined,
+        headers: { authorization: 'Bearer tok' },
+      } as unknown as AuthenticatedRequest;
+
+      await expect(controller.getProfile(req)).rejects.toThrow(
+        UnauthorizedException,
+      );
+    });
+
+    it('debe lanzar UnauthorizedException si no hay header de autorización', async () => {
+      const req = {
+        user: { id: 'user-1' },
+        headers: {},
+      } as unknown as AuthenticatedRequest;
+
+      await expect(controller.getProfile(req)).rejects.toThrow(
+        UnauthorizedException,
+      );
+    });
+
+    it('debe lanzar UnauthorizedException si el token no está en el header', async () => {
+      const req = {
+        user: { id: 'user-1' },
+        headers: { authorization: 'Bearer' },
+      } as unknown as AuthenticatedRequest;
+
+      // 'Bearer'.split(' ')[1] es undefined
+      await expect(controller.getProfile(req)).rejects.toThrow(
+        UnauthorizedException,
+      );
+    });
+  });
+
+  describe('getMe', () => {
+    it('debe retornar datos del usuario autenticado', async () => {
+      const req = {
+        user: { id: 'user-1', email: 'test@email.com' },
+      } as unknown as AuthenticatedRequest;
+
+      getMeUseCase.getMyProfile.mockResolvedValue({
+        id: 'user-1',
+        email: 'test@email.com',
+        nombre: 'Test',
+        rol: RolUsuario.jugador,
+      });
+
+      const result = await controller.getMe(req);
+      expect(result.id).toBe('user-1');
+    });
+
+    it('debe lanzar UnauthorizedException si no hay usuario', async () => {
+      const req = {
+        user: undefined,
+      } as unknown as AuthenticatedRequest;
+
+      await expect(controller.getMe(req)).rejects.toThrow(
+        UnauthorizedException,
+      );
+    });
+  });
+
+  describe('verifyToken', () => {
+    it('debe retornar éxito si el usuario está autenticado', () => {
+      const req = {
+        user: { id: 'user-1', email: 'test@email.com' },
+      } as unknown as AuthenticatedRequest;
+
+      const result = controller.verifyToken(req);
+      expect(result.success).toBe(true);
+    });
+
+    it('debe lanzar UnauthorizedException si no hay usuario', () => {
+      const req = {
+        user: undefined,
+      } as unknown as AuthenticatedRequest;
+
+      expect(() => controller.verifyToken(req)).toThrow(UnauthorizedException);
+    });
+  });
+
+  describe('forgotPassword', () => {
+    it('debe delegar al forgotPasswordUseCase', async () => {
+      forgotPasswordUseCase.forgotPassword.mockResolvedValue({
+        message:
+          'If the email is registered, you will receive a recovery link.',
+      });
+
+      const result = await controller.forgotPassword({
+        email: 'test@email.com',
+      });
+
+      expect(result.message).toContain('recovery link');
+    });
+  });
+
+  describe('resetPassword', () => {
+    it('debe delegar al resetPasswordUseCase', async () => {
+      resetPasswordUseCase.resetPassword.mockResolvedValue({
+        message: 'Contraseña actualizada correctamente',
+      });
+
+      const result = await controller.resetPassword({
+        accessToken: 'tok',
+        newPassword: 'NewPass123',
+        confirmPassword: 'NewPass123',
+      });
+
+      expect(result.message).toContain('actualizada');
+    });
+  });
+
+  describe('signInTestestuser', () => {
+    it('debe delegar al createTestUserService en entorno no producción', async () => {
+      const originalEnv = process.env.NODE_ENV;
+      process.env.NODE_ENV = 'development';
+
+      createTestUserService.signInTestuser.mockResolvedValue({
+        success: true,
+        user: {},
+        session: {},
+        access_token: 'tok',
+        refreshToken: 'ref',
+        message: 'Login successful',
+      } as any);
+
+      const result = await controller.signInTestestuser({
+        email: 'admin@email.com',
+        password: 'Password1',
+      });
+
+      expect(result.success).toBe(true);
+      process.env.NODE_ENV = originalEnv;
+    });
+
+    it('debe lanzar UnauthorizedException en producción', async () => {
+      const originalEnv = process.env.NODE_ENV;
+      process.env.NODE_ENV = 'production';
+
+      await expect(
+        controller.signInTestestuser({
+          email: 'admin@email.com',
+          password: 'Password1',
+        }),
+      ).rejects.toThrow(UnauthorizedException);
+
+      process.env.NODE_ENV = originalEnv;
+    });
+  });
+});

--- a/goblinhub-api/src/modules/supabase/infrastructure/controller/supabase-auth.controller.ts
+++ b/goblinhub-api/src/modules/supabase/infrastructure/controller/supabase-auth.controller.ts
@@ -28,6 +28,9 @@ import { SupabaseAuthGuard } from '../../guard/supabse-auth.guard';
 import type { AuthenticatedRequest } from '../../interfaces/types/authenticated-request.interface';
 import { ForgotPasswordUseCase } from '../../application/use-case/forgot-password.use-case';
 import { ResetPasswordUseCase } from '../../application/use-case/reset-password.use-case';
+import { Throttle } from '@nestjs/throttler';
+import { Roles } from '../../guard/roles.decorator';
+import { RolUsuario } from '../../domain/enums/user.enum';
 
 @Controller('auth')
 export class SupabaseAuthController {
@@ -44,6 +47,7 @@ export class SupabaseAuthController {
   ) {}
 
   /** Endpoint de login limpio — solo devuelve access_token y refresh_token */
+  @Throttle({ default: { limit: 5, ttl: 90000 } })
   @Post('signin')
   @HttpCode(HttpStatus.OK)
   async signIn(@Body() dto: SignInDto) {
@@ -53,6 +57,7 @@ export class SupabaseAuthController {
     );
   }
 
+  @Throttle({ default: { limit: 5, ttl: 90000 } })
   @Post('signup')
   @HttpCode(HttpStatus.CREATED)
   async signUp(@Body() registerUserDto: RegisterUserDto) {
@@ -108,12 +113,14 @@ export class SupabaseAuthController {
     };
   }
 
+  @Throttle({ default: { limit: 5, ttl: 90000 } })
   @Post('forgot-password')
   @HttpCode(HttpStatus.OK)
   async forgotPassword(@Body() dto: ForgotPasswordDto) {
     return await this.forgotPasswordUseCase.forgotPassword(dto.email);
   }
 
+  @Throttle({ default: { limit: 5, ttl: 90000 } })
   @Post('reset-password')
   @HttpCode(HttpStatus.OK)
   async resetPassword(@Body() dto: ResetPasswordDto) {
@@ -126,6 +133,7 @@ export class SupabaseAuthController {
 
   /** Solo para desarrollo/testing interno — bloqueado en producción */
   @Post('test/signin')
+  @Roles(RolUsuario.admin)
   @HttpCode(HttpStatus.OK)
   async signInTestestuser(@Body() signInTestUserDto: SignInTestuserDto) {
     if (process.env.NODE_ENV === 'production') {

--- a/goblinhub-api/src/modules/supabase/infrastructure/prisma/usuario.repository.spec.ts
+++ b/goblinhub-api/src/modules/supabase/infrastructure/prisma/usuario.repository.spec.ts
@@ -1,0 +1,73 @@
+import { UsuarioRepositoryPrisma } from './usuario.repository';
+import { PrismaService } from '../../../../connect/prisma.service';
+import { RolUsuario } from '../../domain/enums/user.enum';
+
+describe('UsuarioRepositoryPrisma', () => {
+  let repository: UsuarioRepositoryPrisma;
+  let prisma: jest.Mocked<PrismaService>;
+  let findUniqueMock: jest.Mock;
+
+  beforeEach(() => {
+    findUniqueMock = jest.fn();
+
+    prisma = {
+      usuario: {
+        findUnique: findUniqueMock,
+      },
+    } as unknown as jest.Mocked<PrismaService>;
+
+    repository = new UsuarioRepositoryPrisma(prisma);
+  });
+
+  describe('findRolById', () => {
+    it('debe retornar el rol del usuario', async () => {
+      findUniqueMock.mockResolvedValue({
+        rol: 'admin',
+      });
+
+      const result = await repository.findRolById('user-123');
+
+      expect(result).toBe(RolUsuario.admin);
+      expect(findUniqueMock).toHaveBeenCalledWith({
+        where: { id_usuario: 'user-123' },
+        select: { rol: true },
+      });
+    });
+
+    it('debe retornar null si el usuario no existe', async () => {
+      findUniqueMock.mockResolvedValue(null);
+
+      const result = await repository.findRolById('nonexistent');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('findProfileById', () => {
+    it('debe retornar el perfil del usuario', async () => {
+      findUniqueMock.mockResolvedValue({
+        rol: 'jugador',
+        nombre: 'Goblin Master',
+      });
+
+      const result = await repository.findProfileById('user-123');
+
+      expect(result).toEqual({
+        rol: RolUsuario.jugador,
+        nombre: 'Goblin Master',
+      });
+      expect(findUniqueMock).toHaveBeenCalledWith({
+        where: { id_usuario: 'user-123' },
+        select: { rol: true, nombre: true },
+      });
+    });
+
+    it('debe retornar null si el usuario no existe', async () => {
+      findUniqueMock.mockResolvedValue(null);
+
+      const result = await repository.findProfileById('nonexistent');
+
+      expect(result).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## 📌 Resumen del Cambio

Se resuelven múltiples vulnerabilidades críticas de seguridad en el backend:

- **Rate limiting global** con `ThrottlerModule` y límites específicos en endpoints sensibles (login, register, forgot-password, signin de prueba).
- **RBAC (Control de acceso basado en roles)** en los módulos de eventos, productos y recompensas, con verificación de propiedad (`id_creador`) para que empleados solo modifiquen sus propios recursos.
- **Validación de contraseña reforzada** en `RegisterUserDto` (mínimo 8 caracteres, mayúscula, minúscula, número y carácter especial).
- **Prevención de enumeración de usuarios** en el endpoint `forgot-password` (respuesta genérica sin importar si el correo existe).
- **Rollback en Prisma** si falla la creación del perfil durante el registro de usuario.
- **Inyección segura del cliente Supabase** en `reset-password` (inyección única en lugar de por request).
- **Flujo completo de recuperación de contraseña**: endpoints `forgot-password` y `reset-password` en backend, y página `ResetPassword` en frontend.
- **66 pruebas unitarias** nuevas para el módulo de autenticación (use-cases, guards, controller, repository).
- **Corrección de RBAC** en update y soft-delete de eventos, alineando tests con las reglas de roles.

---

## 🔍 Tipo de Cambio realizado

Marca con una `x` lo que aplica:

- [x] 🐞 Corrección de error (`fix`)
- [x] ✨ Nueva funcionalidad (`feat`)
- [x] ♻️ Refactorización del código sin cambios funcionales (`refactor`)
- [x] 🧪 Agregado o mejora de pruebas (`test`)
- [ ] 🧱 Cambio en configuración CI/CD (`ci`)
- [ ] 🚀 Mejora de rendimiento (`perf`)
- [ ] 📚 Cambios en la documentación (`docs`)
- [ ] Otro (especificar):

---

## 📂 Archivos Afectados

**Seguridad y rate limiting:**

- `goblinhub-api/package.json` (dependencia `@nestjs/throttler`)
- `goblinhub-api/src/app.module.ts` (ThrottlerModule global)
- `goblinhub-api/src/modules/supabase/interfaces/controller/supabase-auth.controller.ts` (rate limits en endpoints sensibles)

**RBAC y ownership (productos, recompensas, eventos):**

- `goblinhub-api/prisma/schema.prisma` (campo `id_creador` en Producto y Recompensa)
- `goblinhub-api/prisma/migrations/20260306052040_add_id_creador_to_producto_and_recompensa/migration.sql`
- `goblinhub-api/src/modules/events/interfaces/controllers/event.controller.ts`
- `goblinhub-api/src/modules/events/application/use-case/update-event.use-case.ts`
- `goblinhub-api/src/modules/events/application/use-case/sd-event.use-case.ts`
- `goblinhub-api/src/modules/products/interfaces/controllers/product.controller.ts`
- `goblinhub-api/src/modules/products/aplication/use-case/create-product.use-case.ts`
- `goblinhub-api/src/modules/products/aplication/use-case/update-product.use-case.ts`
- `goblinhub-api/src/modules/products/aplication/use-case/soft-deled-product.use-case.ts`
- `goblinhub-api/src/modules/products/domain/entities/product.entity.ts`
- `goblinhub-api/src/modules/products/domain/repositories/product.respository.ts`
- `goblinhub-api/src/modules/products/infrastructure/prisma/product.repository.ts`
- `goblinhub-api/src/modules/rewards/interfaces/controllers/reward.controller.ts`
- `goblinhub-api/src/modules/rewards/aplication/use-case/create-reward.use-case.ts`
- `goblinhub-api/src/modules/rewards/aplication/use-case/update-reward.use-case.ts`
- `goblinhub-api/src/modules/rewards/aplication/use-case/sd-reward.use-case.ts`
- `goblinhub-api/src/modules/rewards/domain/entities/reward.entity.ts`
- `goblinhub-api/src/modules/rewards/domain/repositories/reward.repository.ts`
- `goblinhub-api/src/modules/rewards/infrastructure/prisma/Reward.repository.ts`

**Autenticación (forgot/reset password, validación, rollback):**

- `goblinhub-api/src/modules/supabase/application/dto/auth.dto.ts`
- `goblinhub-api/src/modules/supabase/application/use-case/register-user.use-case.ts`
- `goblinhub-api/src/modules/supabase/application/use-case/forgot-password.use-case.ts` _(nuevo)_
- `goblinhub-api/src/modules/supabase/application/use-case/reset-password.use-case.ts` _(nuevo)_
- `goblinhub-api/src/modules/supabase/application/use-case/signin.use-case.ts`
- `goblinhub-api/src/modules/supabase/application/use-case/getMe.use-case.ts`
- `goblinhub-api/src/modules/supabase/application/use-case/getUserProfile.use-case.ts`
- `goblinhub-api/src/modules/supabase/supabase-auth.module.ts`
- `goblinhub-api/src/modules/supabase/supabase.module.ts`

**Pruebas unitarias (nuevas):**

- `goblinhub-api/src/modules/supabase/application/use-case/forgot-password.use-case.spec.ts`
- `goblinhub-api/src/modules/supabase/application/use-case/getMe.use-case.spec.ts`
- `goblinhub-api/src/modules/supabase/application/use-case/getUserProfile.use-case.spec.ts`
- `goblinhub-api/src/modules/supabase/application/use-case/login-user.use-case.spec.ts`
- `goblinhub-api/src/modules/supabase/application/use-case/refreshT.use-case.spec.ts`
- `goblinhub-api/src/modules/supabase/application/use-case/register-user.use-case.spec.ts`
- `goblinhub-api/src/modules/supabase/application/use-case/reset-password.use-case.spec.ts`
- `goblinhub-api/src/modules/supabase/application/use-case/signin.use-case.spec.ts`
- `goblinhub-api/src/modules/supabase/application/use-case/validationT.use-case.spec.ts`
- `goblinhub-api/src/modules/supabase/guard/roles.guard.spec.ts`
- `goblinhub-api/src/modules/supabase/guard/supabse-auth.guard.spec.ts`
- `goblinhub-api/src/modules/supabase/interfaces/controller/supabase-auth.controller.spec.ts`
- `goblinhub-api/src/modules/supabase/infrastructure/prisma/usuario.repository.spec.ts`
- `goblinhub-api/src/modules/events/application/use-case/update-event.use-case.spec.ts`
- `goblinhub-api/src/modules/events/application/use-case/sd-event.use-case.spec.ts`
- `goblinhub-api/src/modules/events/application/use-case/expire-events.use-case.spec.ts`
- `goblinhub-api/src/modules/rewards/aplication/use-case/create-reward.use-case.spec.ts`
- `goblinhub-api/src/modules/rewards/aplication/use-case/soft-delete-reward.use-case.spec.ts`
- `goblinhub-api/src/modules/rewards/aplication/use-case/update-reward.use-case.spec.ts`

**Frontend:**

- `goblinhub_web/src/App.tsx` (ruta `/reset-password`)
- `goblinhub_web/src/pages/login/Login.tsx` (enlace a forgot-password)
- `goblinhub_web/src/pages/resetPassword/ResetPassword.tsx` _(nuevo)_
- `goblinhub_web/src/services/auth.service.ts` (funciones forgotPassword y resetPassword)

**Refactorización:**

- `goblinhub-api/src/modules/events/scheduler/event-expiration.scheduler.ts` (rename execute → expireAndSoftDeleteEvents)

---

## 🧪 ¿Cómo Probarlo?

### Backend

1. `cd goblinhub-api && npm install`
2. Ejecutar migraciones: `npx prisma migrate dev`
3. Ejecutar pruebas unitarias: `npm run test`
4. Iniciar servidor: `npm run start:dev`
5. Verificar rate limiting: enviar más de 10 requests en 60s a `POST /auth/login` y confirmar respuesta `429 Too Many Requests`
6. Probar RBAC: intentar actualizar/eliminar un producto o recompensa con un usuario que no sea el creador ni admin → debe retornar `403 Forbidden`
7. Probar forgot-password: `POST /auth/forgot-password` con un correo inexistente → debe retornar mensaje genérico sin revelar si el correo existe
8. Probar reset-password: completar flujo con token recibido por correo

### Frontend

1. `cd goblinhub_web && npm install && npm run dev`
2. Ir a `/login` y verificar que aparece el enlace "¿Olvidaste tu contraseña?"
3. Completar el flujo de recuperación de contraseña en `/reset-password`

---

## ✅ Checklist

Asegúrate de completar lo siguiente antes de enviar:

- [x] He probado mis cambios localmente
- [x] Esta PR sigue el formato de convención de commits (si aplica)
- [x] Se han actualizado o agregado pruebas
- [ ] La documentación se actualizó si fue necesario
- [ ] No hay errores en CI/CD

---

## 📎 Notas Adicionales

Este PR resuelve el issue #96.

**Dependencia nueva:** `@nestjs/throttler` — se requiere `npm install` en el backend.

**Migración de BD:** se agrega el campo `id_creador` (nullable) a las tablas `Producto` y `Recompensa`. Ejecutar `npx prisma migrate dev` antes de probar.

**Vulnerabilidades resueltas (OWASP):**

- **Broken Access Control:** RBAC con guards y verificación de ownership en productos, recompensas y eventos.
- **Identification and Authentication Failures:** validación de contraseña reforzada, prevención de enumeración de usuarios, rate limiting en endpoints de autenticación.
- **Security Misconfiguration:** inyección segura del cliente Supabase, rollback en caso de fallo de Prisma durante registro.

---

Gracias 🙌
