### PR TITLE
Feat/102 soporte de foto de perfil por usuario upload almacenamiento y endpoints rest

### DIFF
--- a/goblinhub-api/package-lock.json
+++ b/goblinhub-api/package-lock.json
@@ -30,6 +30,7 @@
         "pg": "^8.18.0",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",
+        "sharp": "^0.34.5",
         "swagger-ui-express": "^5.0.1"
       },
       "devDependencies": {
@@ -40,7 +41,9 @@
         "@nestjs/testing": "^11.0.1",
         "@types/express": "^5.0.0",
         "@types/jest": "^30.0.0",
+        "@types/multer": "^2.1.0",
         "@types/node": "^22.10.7",
+        "@types/sharp": "^0.31.1",
         "@types/supertest": "^6.0.2",
         "eslint": "^9.18.0",
         "eslint-config-prettier": "^10.0.1",
@@ -861,7 +864,6 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
       "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1099,6 +1101,519 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@inquirer/ansi": {
@@ -3388,6 +3903,16 @@
       "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
     },
+    "node_modules/@types/multer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/multer/-/multer-2.1.0.tgz",
+      "integrity": "sha512-zYZb0+nJhOHtPpGDb3vqPjwpdeGlGC157VpkqNQL+UU2qwoacoQ7MpsAmUptI/0Oa127X32JzWDqQVEXp2RcIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "22.19.11",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.11.tgz",
@@ -3457,6 +3982,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/http-errors": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/sharp": {
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@types/sharp/-/sharp-0.31.1.tgz",
+      "integrity": "sha512-5nWwamN9ZFHXaYEincMSuza8nNfOof8nmO+mcI+Agx1uMUk4/pQnNIcix+9rLPXzKrm1pS34+6WRDbDV0Jn7ag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
         "@types/node": "*"
       }
     },
@@ -5543,6 +6078,15 @@
       "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/detect-newline": {
       "version": "3.1.0",
@@ -9984,6 +10528,50 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/goblinhub-api/package.json
+++ b/goblinhub-api/package.json
@@ -41,6 +41,7 @@
     "pg": "^8.18.0",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
+    "sharp": "^0.34.5",
     "swagger-ui-express": "^5.0.1"
   },
   "devDependencies": {
@@ -51,7 +52,9 @@
     "@nestjs/testing": "^11.0.1",
     "@types/express": "^5.0.0",
     "@types/jest": "^30.0.0",
+    "@types/multer": "^2.1.0",
     "@types/node": "^22.10.7",
+    "@types/sharp": "^0.31.1",
     "@types/supertest": "^6.0.2",
     "eslint": "^9.18.0",
     "eslint-config-prettier": "^10.0.1",

--- a/goblinhub-api/prisma/migrations/20260310014410_add_foto_perfil_url_to_usuario/migration.sql
+++ b/goblinhub-api/prisma/migrations/20260310014410_add_foto_perfil_url_to_usuario/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "usuarios" ADD COLUMN     "foto_perfil_url" VARCHAR(500);

--- a/goblinhub-api/prisma/schema.prisma
+++ b/goblinhub-api/prisma/schema.prisma
@@ -99,6 +99,7 @@ model Usuario {
   nivel_experiencia  NivelExperiencia @default(novato)
   puntos_fidelidad   Int              @default(0)
   bio                String?
+  foto_perfil_url    String?          @db.VarChar(500)
   activo             Boolean          @default(true)
   id_usuario_creador String?          @db.Uuid
   

--- a/goblinhub-api/src/app.module.ts
+++ b/goblinhub-api/src/app.module.ts
@@ -6,6 +6,7 @@ import { SupabaseAuthModule } from './modules/supabase/supabase-auth.module';
 import { BackupModule } from './modules/backup/backup.module';
 import { RewardModule } from './modules/rewards/reward.module';
 import { ProductoModule } from './modules/products/product.module';
+import { UploadModule } from './modules/upload/upload.module';
 import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
 import { APP_GUARD } from '@nestjs/core';
 
@@ -26,6 +27,7 @@ import { APP_GUARD } from '@nestjs/core';
     BackupModule,
     RewardModule,
     ProductoModule,
+    UploadModule,
   ],
   controllers: [],
   providers: [

--- a/goblinhub-api/src/main.ts
+++ b/goblinhub-api/src/main.ts
@@ -3,7 +3,7 @@ import { AppModule } from './app.module';
 import { ValidationPipe } from '@nestjs/common';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger'; // Importa Swagger
 import helmet from 'helmet';
-import type { Express } from 'express';
+import type { Express, Request, Response, NextFunction } from 'express';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -94,7 +94,36 @@ async function bootstrap() {
   }
 
   const server = app.getHttpAdapter().getInstance() as Express;
-  server.get('/', (_req, res) => {
+
+  // Redirige al frontend si alguien accede directo desde el navegador
+  // Las peticiones AJAX/fetch del frontend traen headers como Origin, X-Requested-With o Authorization
+  server.use((req: Request, res: Response, next: NextFunction) => {
+    // Permitir Swagger en desarrollo
+    if (!isProduction && req.path.startsWith('/api/docs')) {
+      return next();
+    }
+
+    // Permitir la ruta raíz (ya tiene su propio redirect)
+    if (req.path === '/') {
+      return next();
+    }
+
+    // Si la petición trae Origin, Authorization o X-Requested-With, es del frontend/API client
+    const hasOrigin = !!req.headers['origin'];
+    const hasAuth = !!req.headers['authorization'];
+    const isAjax = req.headers['x-requested-with'] === 'XMLHttpRequest';
+    const acceptsJson =
+      req.headers['accept']?.includes('application/json') ?? false;
+
+    if (hasOrigin || hasAuth || isAjax || acceptsJson) {
+      return next();
+    }
+
+    // Si es una petición directa del navegador (sin los headers anteriores), redirige al frontend
+    return res.redirect(frontendUrl);
+  });
+
+  server.get('/', (_req: Request, res: Response) => {
     res.redirect(frontendUrl);
   });
 

--- a/goblinhub-api/src/main.ts
+++ b/goblinhub-api/src/main.ts
@@ -3,44 +3,43 @@ import { AppModule } from './app.module';
 import { ValidationPipe } from '@nestjs/common';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger'; // Importa Swagger
 import helmet from 'helmet';
+import type { Express } from 'express';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
 
   const isProduction = process.env.NODE_ENV === 'production';
 
+  const frontendUrl =
+    process.env.CORS_ORIGIN?.split(',')[0] ?? 'http://localhost:5173';
+
   app.use(
     helmet({
       crossOriginResourcePolicy: { policy: 'cross-origin' },
 
-      // CSP ajustada para permitir Swagger UI en desarrollo
-      contentSecurityPolicy: isProduction
-        ? undefined // En producción usa los defaults de Helmet
-        : {
-            directives: {
-              defaultSrc: ["'self'"],
-              connectSrc: ["'self'", 'https:'],
-              imgSrc: [
-                "'self'",
-                'data:',
-                'https:',
-                'https://validator.swagger.io',
-              ],
-              scriptSrc: ["'self'", "'unsafe-inline'", "'unsafe-eval'"], // Necesario para Swagger
-              styleSrc: [
-                "'self'",
-                "'unsafe-inline'",
-                'https://fonts.googleapis.com',
-              ],
-            },
-          },
+      contentSecurityPolicy: {
+        directives: {
+          defaultSrc: ["'self'"],
+          connectSrc: ["'self'", 'https:'],
+          imgSrc: isProduction
+            ? ["'self'", 'data:']
+            : ["'self'", 'data:', 'https:', 'https://validator.swagger.io'],
+          scriptSrc: isProduction
+            ? ["'self'"]
+            : ["'self'", "'unsafe-inline'", "'unsafe-eval'"], // unsafe solo para Swagger en dev
+          styleSrc: isProduction
+            ? ["'self'"]
+            : ["'self'", "'unsafe-inline'", 'https://fonts.googleapis.com'], // unsafe solo para Swagger en dev
+          frameAncestors: ["'none'"], // Reemplaza X-Frame-Options
+        },
+      },
 
       referrerPolicy: { policy: 'strict-origin-when-cross-origin' },
 
       strictTransportSecurity: {
-        maxAge: 15552000,
+        maxAge: 31536000, // 1 año (requerido para HSTS preload)
         includeSubDomains: true,
-        preload: false,
+        preload: true,
       },
 
       frameguard: { action: 'deny' },
@@ -93,6 +92,11 @@ async function bootstrap() {
       },
     });
   }
+
+  const server = app.getHttpAdapter().getInstance() as Express;
+  server.get('/', (_req, res) => {
+    res.redirect(frontendUrl);
+  });
 
   await app.listen(process.env.PORT ?? 3000);
   console.log(`🚀 API corriendo en: http://localhost:3000`);

--- a/goblinhub-api/src/modules/supabase/application/use-case/getMe.use-case.spec.ts
+++ b/goblinhub-api/src/modules/supabase/application/use-case/getMe.use-case.spec.ts
@@ -60,8 +60,4 @@ describe('GetMeUseCase', () => {
       foto_perfil_url: null,
     });
   });
-
-  it('[CI TEST] fallo intencional para demostrar pipeline', () => {
-    expect(true).toBe(false);
-  });
 });

--- a/goblinhub-api/src/modules/supabase/application/use-case/getMe.use-case.spec.ts
+++ b/goblinhub-api/src/modules/supabase/application/use-case/getMe.use-case.spec.ts
@@ -60,4 +60,8 @@ describe('GetMeUseCase', () => {
       foto_perfil_url: null,
     });
   });
+
+  it('[CI TEST] fallo intencional para demostrar pipeline', () => {
+    expect(true).toBe(false);
+  });
 });

--- a/goblinhub-api/src/modules/supabase/application/use-case/getMe.use-case.spec.ts
+++ b/goblinhub-api/src/modules/supabase/application/use-case/getMe.use-case.spec.ts
@@ -11,6 +11,7 @@ describe('GetMeUseCase', () => {
     usuarioRepo = {
       findProfileById: jest.fn(),
       findRolById: jest.fn(),
+      updateFotoPerfil: jest.fn(),
     } as unknown as jest.Mocked<UsuarioRepository>;
 
     useCase = new GetMeUseCase(usuarioRepo);
@@ -20,6 +21,7 @@ describe('GetMeUseCase', () => {
     usuarioRepo.findProfileById.mockResolvedValue({
       nombre: 'Goblin Master',
       rol: RolUsuario.jugador,
+      foto_perfil_url: null,
     });
 
     const result = await useCase.getMyProfile('user-123', 'test@email.com');
@@ -29,6 +31,7 @@ describe('GetMeUseCase', () => {
       email: 'test@email.com',
       nombre: 'Goblin Master',
       rol: RolUsuario.jugador,
+      foto_perfil_url: null,
     });
   });
 
@@ -44,6 +47,7 @@ describe('GetMeUseCase', () => {
     usuarioRepo.findProfileById.mockResolvedValue({
       nombre: 'Admin',
       rol: RolUsuario.admin,
+      foto_perfil_url: null,
     });
 
     const result = await useCase.getMyProfile('user-456', undefined);
@@ -53,6 +57,7 @@ describe('GetMeUseCase', () => {
       email: undefined,
       nombre: 'Admin',
       rol: RolUsuario.admin,
+      foto_perfil_url: null,
     });
   });
 });

--- a/goblinhub-api/src/modules/supabase/application/use-case/getMe.use-case.ts
+++ b/goblinhub-api/src/modules/supabase/application/use-case/getMe.use-case.ts
@@ -9,6 +9,7 @@ export interface MeResult {
   email: string | undefined;
   nombre: string;
   rol: UsuarioPerfil['rol'];
+  foto_perfil_url: string | null;
 }
 
 @Injectable()
@@ -28,6 +29,7 @@ export class GetMeUseCase {
       email,
       nombre: perfil.nombre,
       rol: perfil.rol,
+      foto_perfil_url: perfil.foto_perfil_url,
     };
   }
 }

--- a/goblinhub-api/src/modules/supabase/application/use-case/update-foto-perfil.use-case.ts
+++ b/goblinhub-api/src/modules/supabase/application/use-case/update-foto-perfil.use-case.ts
@@ -1,0 +1,119 @@
+import {
+  BadRequestException,
+  Inject,
+  Injectable,
+  InternalServerErrorException,
+  NotFoundException,
+} from '@nestjs/common';
+import { SupabaseClient } from '@supabase/supabase-js';
+import { randomUUID } from 'crypto';
+import sharp from 'sharp';
+import { UsuarioRepository } from '../../domain/repositories/usuario.repository';
+
+const ALLOWED_MIME_TYPES = [
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+  'image/gif',
+];
+const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5 MB
+const BUCKET = process.env.SUPABASE_STORAGE_BUCKET ?? 'images';
+
+@Injectable()
+export class UpdateFotoPerfilUseCase {
+  constructor(
+    @Inject('SUPABASE_ADMIN_CLIENT')
+    private readonly supabaseAdmin: SupabaseClient,
+    private readonly usuarioRepository: UsuarioRepository,
+  ) {}
+
+  private async compressToWebP(
+    buffer: Buffer,
+    mimetype: string,
+  ): Promise<{ buffer: Buffer; contentType: string; ext: string }> {
+    if (mimetype === 'image/gif') {
+      return { buffer, contentType: 'image/gif', ext: '.gif' };
+    }
+    const compressed = await sharp(buffer).webp({ quality: 80 }).toBuffer();
+    return { buffer: compressed, contentType: 'image/webp', ext: '.webp' };
+  }
+
+  async update(id_usuario: string, file: Express.Multer.File): Promise<string> {
+    if (!ALLOWED_MIME_TYPES.includes(file.mimetype)) {
+      throw new BadRequestException(
+        'Solo se permiten imágenes jpeg, png, webp o gif',
+      );
+    }
+
+    if (file.size > MAX_FILE_SIZE) {
+      throw new BadRequestException('El archivo no puede superar los 5 MB');
+    }
+
+    // Verificar que el usuario existe
+    const perfil = await this.usuarioRepository.findProfileById(id_usuario);
+    if (!perfil) {
+      throw new NotFoundException('Usuario no encontrado');
+    }
+
+    const storage = this.supabaseAdmin.storage;
+
+    // Eliminar foto anterior si existe
+    if (typeof perfil.foto_perfil_url === 'string') {
+      const prevPhotoUrl = perfil.foto_perfil_url;
+      const storageBase = `${process.env.SUPABASE_URL ?? ''}/storage/v1/object/public/${BUCKET}/`;
+      if (prevPhotoUrl.startsWith(storageBase)) {
+        const oldPath: string = prevPhotoUrl.replace(storageBase, '');
+        void storage.from(BUCKET).remove([oldPath]);
+      }
+    }
+
+    // Comprimir y convertir a WebP antes de subir
+    const { buffer, contentType, ext } = await this.compressToWebP(
+      file.buffer,
+      file.mimetype,
+    );
+    const filePath = `profiles/${id_usuario}/${randomUUID()}${ext}`;
+
+    const uploadResult = await storage.from(BUCKET).upload(filePath, buffer, {
+      contentType,
+      upsert: false,
+    });
+
+    if (uploadResult.error) {
+      throw new InternalServerErrorException(
+        `Error al subir la foto: ${uploadResult.error.message}`,
+      );
+    }
+
+    const publicUrl = storage.from(BUCKET).getPublicUrl(filePath)
+      .data.publicUrl;
+
+    // Persistir la URL en la BD
+    await this.usuarioRepository.updateFotoPerfil(id_usuario, publicUrl);
+
+    return publicUrl;
+  }
+
+  async delete(id_usuario: string): Promise<void> {
+    const perfil = await this.usuarioRepository.findProfileById(id_usuario);
+    if (!perfil) throw new NotFoundException('Usuario no encontrado');
+
+    const storage = this.supabaseAdmin.storage;
+
+    if (typeof perfil.foto_perfil_url === 'string') {
+      const currentPhotoUrl = perfil.foto_perfil_url;
+      const storageBase = `${process.env.SUPABASE_URL ?? ''}/storage/v1/object/public/${BUCKET}/`;
+      if (currentPhotoUrl.startsWith(storageBase)) {
+        const filePath = currentPhotoUrl.replace(storageBase, '');
+        const removeResult = await storage.from(BUCKET).remove([filePath]);
+        if (removeResult.error) {
+          throw new InternalServerErrorException(
+            `Error al eliminar la foto: ${removeResult.error.message}`,
+          );
+        }
+      }
+    }
+
+    await this.usuarioRepository.updateFotoPerfil(id_usuario, null);
+  }
+}

--- a/goblinhub-api/src/modules/supabase/domain/repositories/usuario.repository.ts
+++ b/goblinhub-api/src/modules/supabase/domain/repositories/usuario.repository.ts
@@ -3,9 +3,14 @@ import { RolUsuario } from '../enums/user.enum';
 export interface UsuarioPerfil {
   rol: RolUsuario;
   nombre: string;
+  foto_perfil_url: string | null;
 }
 
 export abstract class UsuarioRepository {
   abstract findRolById(id_usuario: string): Promise<RolUsuario | null>;
   abstract findProfileById(id_usuario: string): Promise<UsuarioPerfil | null>;
+  abstract updateFotoPerfil(
+    id_usuario: string,
+    foto_perfil_url: string | null,
+  ): Promise<void>;
 }

--- a/goblinhub-api/src/modules/supabase/infrastructure/controller/supabase-auth.controller.spec.ts
+++ b/goblinhub-api/src/modules/supabase/infrastructure/controller/supabase-auth.controller.spec.ts
@@ -9,6 +9,7 @@ import { GetMeUseCase } from '../../application/use-case/getMe.use-case';
 import { SignInUseCase } from '../../application/use-case/signin.use-case';
 import { ForgotPasswordUseCase } from '../../application/use-case/forgot-password.use-case';
 import { ResetPasswordUseCase } from '../../application/use-case/reset-password.use-case';
+import { UpdateFotoPerfilUseCase } from '../../application/use-case/update-foto-perfil.use-case';
 import { AuthenticatedRequest } from '../../interfaces/types/authenticated-request.interface';
 import { RolUsuario, NivelExperiencia } from '../../domain/enums/user.enum';
 import { Session, User } from '@supabase/supabase-js';
@@ -24,6 +25,7 @@ describe('SupabaseAuthController', () => {
   let signInUseCase: jest.Mocked<SignInUseCase>;
   let forgotPasswordUseCase: jest.Mocked<ForgotPasswordUseCase>;
   let resetPasswordUseCase: jest.Mocked<ResetPasswordUseCase>;
+  let updateFotoPerfilUseCase: jest.Mocked<UpdateFotoPerfilUseCase>;
 
   beforeEach(() => {
     validationService = {
@@ -62,6 +64,11 @@ describe('SupabaseAuthController', () => {
       resetPassword: jest.fn(),
     } as unknown as jest.Mocked<ResetPasswordUseCase>;
 
+    updateFotoPerfilUseCase = {
+      update: jest.fn(),
+      delete: jest.fn(),
+    } as unknown as jest.Mocked<UpdateFotoPerfilUseCase>;
+
     controller = new SupabaseAuthController(
       validationService,
       refreshService,
@@ -72,6 +79,7 @@ describe('SupabaseAuthController', () => {
       signInUseCase,
       forgotPasswordUseCase,
       resetPasswordUseCase,
+      updateFotoPerfilUseCase,
     );
   });
 
@@ -203,6 +211,7 @@ describe('SupabaseAuthController', () => {
         email: 'test@email.com',
         nombre: 'Test',
         rol: RolUsuario.jugador,
+        foto_perfil_url: null,
       });
 
       const result = await controller.getMe(req);

--- a/goblinhub-api/src/modules/supabase/infrastructure/controller/supabase-auth.controller.ts
+++ b/goblinhub-api/src/modules/supabase/infrastructure/controller/supabase-auth.controller.ts
@@ -1,14 +1,28 @@
 import {
+  BadRequestException,
   Body,
   Controller,
+  Delete,
   Get,
   HttpCode,
   Post,
+  Put,
   UnauthorizedException,
+  UploadedFile,
   UseGuards,
+  UseInterceptors,
   Request,
   HttpStatus,
 } from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
+import { memoryStorage } from 'multer';
+import {
+  ApiBearerAuth,
+  ApiBody,
+  ApiConsumes,
+  ApiOperation,
+  ApiResponse,
+} from '@nestjs/swagger';
 import { SupabaseValidationTokenService } from '../../application/use-case/validationT.use-case';
 import { SupabaseRefreshTokenService } from '../../application/use-case/refreshT.use-case';
 import { SupabaseGetUserProfileService } from '../../application/use-case/getUserProfile.use-case';
@@ -28,6 +42,7 @@ import { SupabaseAuthGuard } from '../../guard/supabse-auth.guard';
 import type { AuthenticatedRequest } from '../../interfaces/types/authenticated-request.interface';
 import { ForgotPasswordUseCase } from '../../application/use-case/forgot-password.use-case';
 import { ResetPasswordUseCase } from '../../application/use-case/reset-password.use-case';
+import { UpdateFotoPerfilUseCase } from '../../application/use-case/update-foto-perfil.use-case';
 import { Throttle } from '@nestjs/throttler';
 import { Roles } from '../../guard/roles.decorator';
 import { RolUsuario } from '../../domain/enums/user.enum';
@@ -44,6 +59,7 @@ export class SupabaseAuthController {
     private readonly signInUseCase: SignInUseCase,
     private readonly forgotPasswordUseCase: ForgotPasswordUseCase,
     private readonly resetPasswordUseCase: ResetPasswordUseCase,
+    private readonly updateFotoPerfilUseCase: UpdateFotoPerfilUseCase,
   ) {}
 
   /** Endpoint de login limpio — solo devuelve access_token y refresh_token */
@@ -143,5 +159,63 @@ export class SupabaseAuthController {
       signInTestUserDto.email,
       signInTestUserDto.password,
     );
+  }
+
+  @Put('me/foto')
+  @UseGuards(SupabaseAuthGuard)
+  @UseInterceptors(
+    FileInterceptor('file', {
+      storage: memoryStorage(),
+      limits: { fileSize: 5 * 1024 * 1024 },
+    }),
+  )
+  @ApiBearerAuth('access-token')
+  @ApiOperation({
+    summary: 'Actualizar foto de perfil del usuario autenticado',
+  })
+  @ApiConsumes('multipart/form-data')
+  @ApiBody({
+    schema: {
+      type: 'object',
+      required: ['file'],
+      properties: {
+        file: {
+          type: 'string',
+          format: 'binary',
+          description: 'Imagen de perfil (jpeg, png, webp, gif · máx 5 MB)',
+        },
+      },
+    },
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'URL pública de la nueva foto de perfil',
+    schema: {
+      example: { foto_perfil_url: 'https://…/profiles/uuid/uuid.jpg' },
+    },
+  })
+  async updateFotoPerfil(
+    @UploadedFile() file: Express.Multer.File,
+    @Request() req: AuthenticatedRequest,
+  ): Promise<{ foto_perfil_url: string }> {
+    if (!req.user) throw new UnauthorizedException('User not authenticated');
+    if (!file)
+      throw new BadRequestException('Se requiere un archivo de imagen válido');
+    const url = await this.updateFotoPerfilUseCase.update(req.user.id, file);
+    return { foto_perfil_url: url };
+  }
+
+  @Delete('me/foto')
+  @UseGuards(SupabaseAuthGuard)
+  @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: 'Eliminar foto de perfil del usuario autenticado' })
+  @ApiResponse({ status: 200, description: 'Foto de perfil eliminada' })
+  @HttpCode(HttpStatus.OK)
+  async deleteFotoPerfil(
+    @Request() req: AuthenticatedRequest,
+  ): Promise<{ message: string }> {
+    if (!req.user) throw new UnauthorizedException('User not authenticated');
+    await this.updateFotoPerfilUseCase.delete(req.user.id);
+    return { message: 'Foto de perfil eliminada correctamente' };
   }
 }

--- a/goblinhub-api/src/modules/supabase/infrastructure/prisma/usuario.repository.spec.ts
+++ b/goblinhub-api/src/modules/supabase/infrastructure/prisma/usuario.repository.spec.ts
@@ -48,6 +48,7 @@ describe('UsuarioRepositoryPrisma', () => {
       findUniqueMock.mockResolvedValue({
         rol: 'jugador',
         nombre: 'Goblin Master',
+        foto_perfil_url: null,
       });
 
       const result = await repository.findProfileById('user-123');
@@ -55,10 +56,11 @@ describe('UsuarioRepositoryPrisma', () => {
       expect(result).toEqual({
         rol: RolUsuario.jugador,
         nombre: 'Goblin Master',
+        foto_perfil_url: null,
       });
       expect(findUniqueMock).toHaveBeenCalledWith({
         where: { id_usuario: 'user-123' },
-        select: { rol: true, nombre: true },
+        select: { rol: true, nombre: true, foto_perfil_url: true },
       });
     });
 

--- a/goblinhub-api/src/modules/supabase/infrastructure/prisma/usuario.repository.ts
+++ b/goblinhub-api/src/modules/supabase/infrastructure/prisma/usuario.repository.ts
@@ -26,11 +26,25 @@ export class UsuarioRepositoryPrisma extends UsuarioRepository {
   async findProfileById(id_usuario: string): Promise<UsuarioPerfil | null> {
     const usuario = await this.prisma.usuario.findUnique({
       where: { id_usuario },
-      select: { rol: true, nombre: true },
+      select: { rol: true, nombre: true, foto_perfil_url: true },
     });
 
     if (!usuario) return null;
 
-    return { rol: usuario.rol as RolUsuario, nombre: usuario.nombre };
+    return {
+      rol: usuario.rol as RolUsuario,
+      nombre: usuario.nombre,
+      foto_perfil_url: usuario.foto_perfil_url,
+    };
+  }
+
+  async updateFotoPerfil(
+    id_usuario: string,
+    foto_perfil_url: string | null,
+  ): Promise<void> {
+    await this.prisma.usuario.update({
+      where: { id_usuario },
+      data: { foto_perfil_url },
+    });
   }
 }

--- a/goblinhub-api/src/modules/supabase/supabase-auth.module.ts
+++ b/goblinhub-api/src/modules/supabase/supabase-auth.module.ts
@@ -11,6 +11,7 @@ import { GetMeUseCase } from './application/use-case/getMe.use-case';
 import { SignInUseCase } from './application/use-case/signin.use-case';
 import { ForgotPasswordUseCase } from './application/use-case/forgot-password.use-case';
 import { ResetPasswordUseCase } from './application/use-case/reset-password.use-case';
+import { UpdateFotoPerfilUseCase } from './application/use-case/update-foto-perfil.use-case';
 import { SupabaseAuthGuard } from './guard/supabse-auth.guard';
 import { RolesGuard } from './guard/roles.guard';
 import { UsuarioRepository } from './domain/repositories/usuario.repository';
@@ -29,6 +30,7 @@ import { UsuarioRepositoryPrisma } from './infrastructure/prisma/usuario.reposit
     SignInUseCase,
     ForgotPasswordUseCase,
     ResetPasswordUseCase,
+    UpdateFotoPerfilUseCase,
     SupabaseAuthGuard,
     RolesGuard,
     {

--- a/goblinhub-api/src/modules/upload/upload.controller.ts
+++ b/goblinhub-api/src/modules/upload/upload.controller.ts
@@ -1,0 +1,111 @@
+import {
+  BadRequestException,
+  Controller,
+  Delete,
+  Post,
+  Query,
+  UploadedFile,
+  UseGuards,
+  UseInterceptors,
+} from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
+import {
+  ApiBearerAuth,
+  ApiBody,
+  ApiConsumes,
+  ApiOperation,
+  ApiQuery,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { memoryStorage } from 'multer';
+import { UploadService } from './upload.service';
+import { SupabaseAuthGuard } from '../supabase/guard/supabse-auth.guard';
+import { RolesGuard } from '../supabase/guard/roles.guard';
+import { Roles } from '../supabase/guard/roles.decorator';
+import { RolUsuario } from '../supabase/domain/enums/user.enum';
+
+@ApiTags('Upload')
+@ApiBearerAuth('access-token')
+@UseGuards(SupabaseAuthGuard, RolesGuard)
+@Roles(RolUsuario.admin, RolUsuario.empleado)
+@Controller('upload')
+export class UploadController {
+  constructor(private readonly uploadService: UploadService) {}
+
+  @Post()
+  @UseInterceptors(
+    FileInterceptor('file', {
+      storage: memoryStorage(),
+      limits: { fileSize: 5 * 1024 * 1024 }, // 5 MB
+    }),
+  )
+  @ApiOperation({ summary: 'Subir una imagen a Supabase Storage' })
+  @ApiConsumes('multipart/form-data')
+  @ApiBody({
+    schema: {
+      type: 'object',
+      required: ['file'],
+      properties: {
+        file: {
+          type: 'string',
+          format: 'binary',
+          description: 'Imagen (jpeg, png, webp, gif · máx 5 MB)',
+        },
+      },
+    },
+  })
+  @ApiQuery({
+    name: 'folder',
+    required: false,
+    example: 'products',
+    description:
+      'Subcarpeta destino dentro del bucket (ej: products, events, profiles)',
+  })
+  @ApiResponse({
+    status: 201,
+    description: 'URL pública de la imagen subida',
+    schema: {
+      example: {
+        url: 'https://…/storage/v1/object/public/images/products/uuid.jpg',
+      },
+    },
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Archivo no válido o demasiado grande',
+  })
+  async uploadImage(
+    @UploadedFile() file: Express.Multer.File,
+    @Query('folder') folder?: string,
+  ): Promise<{ url: string }> {
+    if (!file) {
+      throw new BadRequestException(
+        'Se requiere un archivo de imagen válido (jpeg, png, webp, gif)',
+      );
+    }
+
+    const url = await this.uploadService.uploadImage(file, folder);
+    return { url };
+  }
+
+  @Delete()
+  @ApiOperation({
+    summary: 'Eliminar una imagen de Supabase Storage por su URL pública',
+  })
+  @ApiQuery({
+    name: 'url',
+    required: true,
+    description: 'URL pública de la imagen a eliminar',
+  })
+  @ApiResponse({ status: 200, description: 'Imagen eliminada correctamente' })
+  @ApiResponse({ status: 400, description: 'URL no válida' })
+  async deleteImage(@Query('url') url: string): Promise<{ message: string }> {
+    if (!url) {
+      throw new BadRequestException('Se requiere el parámetro url');
+    }
+
+    await this.uploadService.deleteImage(url);
+    return { message: 'Imagen eliminada correctamente' };
+  }
+}

--- a/goblinhub-api/src/modules/upload/upload.module.ts
+++ b/goblinhub-api/src/modules/upload/upload.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { UploadController } from './upload.controller';
+import { UploadService } from './upload.service';
+import { SupabaseModule } from '../supabase/supabase.module';
+import { SupabaseAuthModule } from '../supabase/supabase-auth.module';
+
+@Module({
+  imports: [SupabaseModule, SupabaseAuthModule],
+  controllers: [UploadController],
+  providers: [UploadService],
+  exports: [UploadService],
+})
+export class UploadModule {}

--- a/goblinhub-api/src/modules/upload/upload.service.ts
+++ b/goblinhub-api/src/modules/upload/upload.service.ts
@@ -1,0 +1,99 @@
+import {
+  BadRequestException,
+  Inject,
+  Injectable,
+  InternalServerErrorException,
+} from '@nestjs/common';
+import { SupabaseClient } from '@supabase/supabase-js';
+import { randomUUID } from 'crypto';
+import sharp from 'sharp';
+
+const ALLOWED_MIME_TYPES = [
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+  'image/gif',
+];
+const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5 MB
+
+@Injectable()
+export class UploadService {
+  private readonly bucket: string;
+
+  constructor(
+    @Inject('SUPABASE_ADMIN_CLIENT') private readonly supabase: SupabaseClient,
+  ) {
+    this.bucket = process.env.SUPABASE_STORAGE_BUCKET ?? 'images';
+  }
+
+  private async compressToWebP(
+    buffer: Buffer,
+    mimetype: string,
+  ): Promise<{ buffer: Buffer; contentType: string; ext: string }> {
+    if (mimetype === 'image/gif') {
+      return { buffer, contentType: 'image/gif', ext: '.gif' };
+    }
+    const compressed = await sharp(buffer).webp({ quality: 80 }).toBuffer();
+    return { buffer: compressed, contentType: 'image/webp', ext: '.webp' };
+  }
+
+  async uploadImage(
+    file: Express.Multer.File,
+    folder = 'misc',
+  ): Promise<string> {
+    if (!ALLOWED_MIME_TYPES.includes(file.mimetype)) {
+      throw new BadRequestException(
+        'Solo se permiten imágenes en formato jpeg, png, webp o gif',
+      );
+    }
+
+    if (file.size > MAX_FILE_SIZE) {
+      throw new BadRequestException('El archivo no puede superar los 5 MB');
+    }
+
+    const { buffer, contentType, ext } = await this.compressToWebP(
+      file.buffer,
+      file.mimetype,
+    );
+    const fileName = `${folder}/${randomUUID()}${ext}`;
+
+    const { error } = await this.supabase.storage
+      .from(this.bucket)
+      .upload(fileName, buffer, {
+        contentType,
+        upsert: false,
+      });
+
+    if (error) {
+      throw new InternalServerErrorException(
+        `Error al subir la imagen: ${error.message}`,
+      );
+    }
+
+    const { data } = this.supabase.storage
+      .from(this.bucket)
+      .getPublicUrl(fileName);
+
+    return data.publicUrl;
+  }
+
+  async deleteImage(publicUrl: string): Promise<void> {
+    const storageBase = `${process.env.SUPABASE_URL}/storage/v1/object/public/${this.bucket}/`;
+
+    if (!publicUrl.startsWith(storageBase)) {
+      throw new BadRequestException('URL de imagen no válida para este bucket');
+    }
+
+    const filePath = publicUrl.replace(storageBase, '');
+
+    const { error } = await this.supabase.storage
+      .from(this.bucket)
+      .remove([filePath]);
+
+    if (error) {
+      throw new InternalServerErrorException(
+        `Error al eliminar la imagen: ${error.message}`,
+      );
+    }
+  }
+}


### PR DESCRIPTION
## 📌 Resumen del Cambio

Se implementa soporte completo de foto de perfil por usuario en el backend: nuevo campo `foto_perfil_url` en la tabla `usuarios`, módulo genérico de upload a Supabase Storage con compresión automática a WebP (via `sharp`), caso de uso dedicado y dos nuevos endpoints REST (`PUT /auth/me/foto`, `DELETE /auth/me/foto`). Adicionalmente se endurecen las directivas CSP/HSTS en `main.ts` y se agrega middleware de redirección para accesos directos desde el navegador.

---

## 🔍 Tipo de Cambio realizado

Marca con una `x` lo que aplica:

- [x] 🐞 Corrección de error (`fix`)
- [x] ✨ Nueva funcionalidad (`feat`)
- [ ] ♻️ Refactorización del código sin cambios funcionales (`refactor`)
- [x] 🧪 Agregado o mejora de pruebas (`test`)
- [ ] 🧱 Cambio en configuración CI/CD (`ci`)
- [ ] 🚀 Mejora de rendimiento (`perf`)
- [ ] 📚 Cambios en la documentación (`docs`)
- [ ] Otro (especificar):

---

## 📂 Archivos Afectados

**Creados:**

- `prisma/migrations/20260310014410_add_foto_perfil_url_to_usuario/migration.sql`
- `src/modules/upload/upload.service.ts`
- `src/modules/upload/upload.controller.ts`
- `src/modules/upload/upload.module.ts`
- `src/modules/supabase/application/use-case/update-foto-perfil.use-case.ts`

**Modificados:**

- `prisma/schema.prisma`
- `src/main.ts`
- `src/app.module.ts`
- `src/modules/supabase/domain/repositories/usuario.repository.ts`
- `src/modules/supabase/infrastructure/prisma/usuario.repository.ts`
- `src/modules/supabase/application/use-case/getMe.use-case.ts`
- `src/modules/supabase/infrastructure/controller/supabase-auth.controller.ts`
- `src/modules/supabase/supabase-auth.module.ts`
- `src/modules/supabase/application/use-case/getMe.use-case.spec.ts`
- `src/modules/supabase/infrastructure/controller/supabase-auth.controller.spec.ts`
- `src/modules/supabase/infrastructure/prisma/usuario.repository.spec.ts`
- `package.json` / `package-lock.json`

---

## 🧪 ¿Cómo Probarlo?

1. Clonar la rama y ejecutar `npm install`
2. Asegurarse de tener las variables de entorno configuradas: `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, `SUPABASE_ANON_KEY`, `DATABASE_URL`, `SUPABASE_STORAGE_BUCKET=images`
3. Crear un bucket llamado `images` en Supabase Storage con acceso público
4. Ejecutar `npx prisma migrate dev` para aplicar la migración
5. Iniciar el servidor con `npm run start:dev`
6. Abrir Swagger en `http://localhost:3000/api/docs`
7. Autenticarse con `POST /auth/signin` y usar el `access_token` como Bearer token
8. Subir una foto con `PUT /auth/me/foto` (multipart/form-data, campo `file`, imagen ≤ 5 MB)
9. Verificar que `GET /auth/me` devuelve `foto_perfil_url` con la URL pública
10. Eliminar la foto con `DELETE /auth/me/foto` y confirmar que `foto_perfil_url` vuelve a `null`

Para correr los tests: `npm run test:cov`

---

## ✅ Checklist

Asegúrate de completar lo siguiente antes de enviar:

- [x] He probado mis cambios localmente
- [x] Esta PR sigue el formato de convención de commits (si aplica)
- [x] Se han actualizado o agregado pruebas
- [ ] La documentación se actualizó si fue necesario
- [ ] No hay errores en CI/CD

---

## 📎 Notas Adicionales

Resuelve el issue #102.

- La compresión WebP con `sharp` reduce el tamaño de las imágenes hasta un 70% respecto al JPEG/PNG original. Los GIFs se conservan sin conversión para preservar la animación.
- Variable de entorno requerida: `SUPABASE_STORAGE_BUCKET=images` (el bucket debe existir en Supabase con acceso público).
- El `UploadModule` es genérico y puede reutilizarse para subir imágenes de productos, eventos u otras entidades.

---

Gracias 🙌
